### PR TITLE
Add github action for linux & windows build 

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -1,0 +1,66 @@
+name: CI
+
+on:
+  push:
+    branches: [ "main", "setup-github-action" ]
+  pull_request:
+    branches: [ "main" ]
+
+jobs:
+  build:
+    runs-on: ${{ matrix.os }}
+    defaults:
+        run:
+            shell: ${{ matrix.shell }}
+
+    strategy:
+      fail-fast: false
+      matrix:
+        os: [ubuntu-latest, windows-latest]
+        build_type: [Release]
+        include:
+          - os: windows-latest
+            arch: 'win64_mingw'
+            host: 'windows'
+            shell: 'msys2 {0}'
+          - os: ubuntu-latest
+            arch: 'gcc_64'
+            host: 'linux'
+            shell: 'bash'
+
+    steps:
+    - uses: actions/checkout@v3
+      with:
+        submodules: 'true'
+
+    - name: Install MSYS2
+      if: matrix.os == 'windows-latest'
+      uses: msys2/setup-msys2@v2
+      with:
+        install: mingw-w64-x86_64-toolchain mingw-w64-x86_64-cmake
+        msystem: mingw64
+        release: false
+    
+    - name: Install Qt
+      uses: jurplel/install-qt-action@v2
+      with:
+        version: '6.5.3'
+        host: ${{ matrix.host }}
+        target: 'desktop'
+        arch: ${{ matrix.arch }}
+        dir: '${{github.workspace}}/qt'
+        install-deps: 'true'     
+    
+    - name: Configure
+      env:
+        CMAKE_PREFIX_PATH: ${{env.Qt6_Dir}}/lib/cmake
+      run: cmake -DCMAKE_BUILD_TYPE=${{env.BUILD_TYPE}} -DALP_ENABLE_POSITIONING=false -B '${{github.workspace}}'/build
+
+    - name: Build
+      run: cmake --build '${{github.workspace}}'/build
+
+    - name: Test
+      run: |
+        '${{github.workspace}}'/build/sherpa/unittests_sherpa
+        '${{github.workspace}}'/build/unittests/unittests_nucleus
+        '${{github.workspace}}'/build/unittests_gl/unittests_gl_engine

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -2,7 +2,7 @@ name: CI
 
 on:
   push:
-    branches: [ "main", "setup-github-action" ]
+    branches: [ "main" ]
   pull_request:
     branches: [ "main" ]
 


### PR DESCRIPTION
This workflow runs on every push & pull request on the main branch. Right now the nucleus unittests fail with a segfault. The Qt install on windows can sometimes fail randomly, I'm not sure why.