### PR TITLE
Add CMake option to disable labels

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -28,16 +28,12 @@ option(ALP_ENABLE_APP_SHUTDOWN_AFTER_60S "Shuts down the app after 60S, used for
 option(ALP_ENABLE_LTO "Enable link time optimisation." OFF)
 option(ALP_ENABLE_GL_ENGINE "Enable OpenGL/WebGL engine" ON)
 option(ALP_ENABLE_AVLANCHE_WARNING_LAYER "Enables avalanche warning layer (requires Qt Gui in nucleus)" OFF)
-option(ALP_ENABLE_LABELS "Enables label rendering" OFF)
+option(ALP_ENABLE_LABELS "Enables label rendering" ON)
 
 set(ALP_EXTERN_DIR "extern" CACHE STRING "name of the directory to store external libraries, fonts etc..")
 
 if(ALP_ENABLE_TRACK_OBJECT_LIFECYCLE)
     add_definitions(-DALP_ENABLE_TRACK_OBJECT_LIFECYCLE)
-endif()
-
-if(ALP_ENABLE_LABELS)
-    add_compile_definitions(ALP_ENABLE_LABELS)
 endif()
 
 if (EMSCRIPTEN)

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -27,8 +27,8 @@ option(ALP_ENABLE_TRACK_OBJECT_LIFECYCLE "enables debug cmd printout of construc
 option(ALP_ENABLE_APP_SHUTDOWN_AFTER_60S "Shuts down the app after 60S, used for CI testing with asan." OFF)
 option(ALP_ENABLE_LTO "Enable link time optimisation." OFF)
 option(ALP_ENABLE_GL_ENGINE "Enable OpenGL/WebGL engine" ON)
-option(ALP_ENABLE_AVLANCHE_WARNING_LAYER "Enables avalanche warning layer (requires Qt Gui in nucleus)" ON)
-option(ALP_ENABLE_LABELS "Enables label rendering" ON)
+option(ALP_ENABLE_AVLANCHE_WARNING_LAYER "Enables avalanche warning layer (requires Qt Gui in nucleus)" OFF)
+option(ALP_ENABLE_LABELS "Enables label rendering" OFF)
 
 set(ALP_EXTERN_DIR "extern" CACHE STRING "name of the directory to store external libraries, fonts etc..")
 

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -28,11 +28,16 @@ option(ALP_ENABLE_APP_SHUTDOWN_AFTER_60S "Shuts down the app after 60S, used for
 option(ALP_ENABLE_LTO "Enable link time optimisation." OFF)
 option(ALP_ENABLE_GL_ENGINE "Enable OpenGL/WebGL engine" ON)
 option(ALP_ENABLE_AVLANCHE_WARNING_LAYER "Enables avalanche warning layer (requires Qt Gui in nucleus)" ON)
+option(ALP_ENABLE_LABELS "Enables label rendering" ON)
 
 set(ALP_EXTERN_DIR "extern" CACHE STRING "name of the directory to store external libraries, fonts etc..")
 
 if(ALP_ENABLE_TRACK_OBJECT_LIFECYCLE)
     add_definitions(-DALP_ENABLE_TRACK_OBJECT_LIFECYCLE)
+endif()
+
+if(ALP_ENABLE_LABELS)
+    add_compile_definitions(ALP_ENABLE_LABELS)
 endif()
 
 if (EMSCRIPTEN)

--- a/gl_engine/CMakeLists.txt
+++ b/gl_engine/CMakeLists.txt
@@ -37,11 +37,17 @@ qt_add_library(gl_engine STATIC
     SSAO.h SSAO.cpp
     ShadowMapping.h ShadowMapping.cpp
     GpuAsyncQueryTimer.h GpuAsyncQueryTimer.cpp
-    MapLabelManager.h MapLabelManager.cpp
     Texture.h Texture.cpp
     TrackManager.h TrackManager.cpp
     Context.h Context.cpp
 )
+
+if(ALP_ENABLE_LABELS)
+    target_sources(gl_engine PRIVATE
+        MapLabelManager.h MapLabelManager.cpp
+    )
+endif()
+
 target_link_libraries(gl_engine PUBLIC nucleus Qt::OpenGL)
 target_include_directories(gl_engine PRIVATE .)
 

--- a/gl_engine/CMakeLists.txt
+++ b/gl_engine/CMakeLists.txt
@@ -46,6 +46,7 @@ if(ALP_ENABLE_LABELS)
     target_sources(gl_engine PRIVATE
         MapLabelManager.h MapLabelManager.cpp
     )
+    target_compile_definitions(gl_engine PUBLIC ALP_ENABLE_LABELS)
 endif()
 
 target_link_libraries(gl_engine PUBLIC nucleus Qt::OpenGL)

--- a/gl_engine/Window.cpp
+++ b/gl_engine/Window.cpp
@@ -54,7 +54,6 @@
 
 #include "Context.h"
 #include "Framebuffer.h"
-#include "MapLabelManager.h"
 #include "SSAO.h"
 #include "ShaderManager.h"
 #include "ShaderProgram.h"
@@ -68,6 +67,10 @@
 #include "GpuAsyncQueryTimer.h"
 #endif
 
+#ifdef ALP_ENABLE_LABELS
+#include "MapLabelManager.h"
+#endif
+
 using gl_engine::UniformBuffer;
 using gl_engine::Window;
 using namespace gl_engine;
@@ -76,7 +79,9 @@ Window::Window()
     : m_camera({ 1822577.0, 6141664.0 - 500, 171.28 + 500 }, { 1822577.0, 6141664.0, 171.28 }) // should point right at the stephansdom
 {
     m_tile_manager = std::make_unique<TileManager>();
+#ifdef ALP_ENABLE_LABELS
     m_map_label_manager = std::make_shared<MapLabelManager>();
+#endif
     QTimer::singleShot(1, [this]() { emit update_requested(); });
 }
 
@@ -146,9 +151,11 @@ void Window::initialise_gpu()
 
     m_shadowmapping = std::make_unique<gl_engine::ShadowMapping>(shader_manager->shared_shadowmap_program(), m_shadow_config_ubo, m_shared_config_ubo);
 
+#ifdef ALP_ENABLE_LABELS
     m_map_label_manager->init();
+#endif
 
-    {   // INITIALIZE CPU AND GPU TIMER
+    { // INITIALIZE CPU AND GPU TIMER
         using namespace std;
         using nucleus::timing::CpuTimer;
         m_timer = std::make_unique<nucleus::timing::TimerManager>();
@@ -312,6 +319,7 @@ void Window::paint(QOpenGLFramebufferObject* framebuffer)
     f->glEnable(GL_DEPTH_TEST);
     f->glDepthFunc(GL_LEQUAL);
 
+#ifdef ALP_ENABLE_LABELS
     // DRAW LABELS
     {
         m_timer->start_timer("labels");
@@ -320,6 +328,7 @@ void Window::paint(QOpenGLFramebufferObject* framebuffer)
         shader_manager->labels_program()->release();
         m_timer->stop_timer("labels");
     }
+#endif
 
     // DRAW TRACKS
     {
@@ -412,8 +421,10 @@ void Window::update_gpu_quads(const std::vector<nucleus::tile_scheduler::tile_ty
     assert(m_tile_manager);
     m_tile_manager->update_gpu_quads(new_quads, deleted_quads);
 
+#ifdef ALP_ENABLE_LABELS
     assert(m_map_label_manager);
     m_map_label_manager->update_gpu_quads(new_quads, deleted_quads);
+#endif
 }
 
 float Window::depth(const glm::dvec2& normalised_device_coordinates)

--- a/nucleus/AbstractRenderWindow.h
+++ b/nucleus/AbstractRenderWindow.h
@@ -25,7 +25,6 @@
 #include <glm/glm.hpp>
 
 #include "nucleus/tile_scheduler/tile_types.h"
-#include "nucleus/vector_tiles/VectorTileFeature.h"
 #include "utils/ColourTexture.h"
 
 class QOpenGLFramebufferObject;

--- a/nucleus/CMakeLists.txt
+++ b/nucleus/CMakeLists.txt
@@ -28,7 +28,9 @@ if (NOT TARGET fmt)
     alp_add_git_repository(fmt URL https://github.com/fmtlib/fmt.git COMMITISH 10.1.1)
 endif()
 alp_add_git_repository(zppbits URL https://github.com/eyalz800/zpp_bits.git COMMITISH v4.4.20 DO_NOT_ADD_SUBPROJECT)
-alp_add_git_repository(vector_tiles URL https://github.com/AlpineMapsOrgDependencies/vector-tile.git COMMITISH origin/main)
+if(ALP_ENABLE_LABELS)
+    alp_add_git_repository(vector_tiles URL https://github.com/AlpineMapsOrgDependencies/vector-tile.git COMMITISH origin/main)
+endif()
 alp_add_git_repository(goofy_tc URL https://github.com/AlpineMapsOrgDependencies/Goofy_slim.git COMMITISH 13b228784960a6227bb6ca704ff34161bbac1b91 DO_NOT_ADD_SUBPROJECT)
 
 add_library(zppbits INTERFACE)
@@ -91,8 +93,6 @@ qt_add_library(nucleus STATIC
     utils/UrlModifier.h utils/UrlModifier.cpp
     utils/bit_coding.h
     utils/sun_calculations.h utils/sun_calculations.cpp
-    map_label/LabelFactory.h map_label/LabelFactory.cpp
-    map_label/MapLabelData.h
     utils/bit_coding.h
     tile_scheduler/cache_quieries.h
     DataQuerier.h DataQuerier.cpp
@@ -101,8 +101,6 @@ qt_add_library(nucleus STATIC
     timing/TimerManager.h timing/TimerManager.cpp
     timing/TimerInterface.h timing/TimerInterface.cpp
     timing/CpuTimer.h timing/CpuTimer.cpp
-    vector_tiles/VectorTileManager.h vector_tiles/VectorTileManager.cpp
-    vector_tiles/VectorTileFeature.h vector_tiles/VectorTileFeature.cpp
     utils/ColourTexture.h utils/ColourTexture.cpp
     EngineContext.h EngineContext.cpp
     track/Manager.h track/Manager.cpp
@@ -117,10 +115,19 @@ if (ALP_ENABLE_AVLANCHE_WARNING_LAYER)
     )
     target_link_libraries(nucleus PUBLIC Qt::Gui)
 endif()
+if(ALP_ENABLE_LABELS)
+    target_sources(nucleus PRIVATE
+        vector_tiles/VectorTileManager.h vector_tiles/VectorTileManager.cpp
+        vector_tiles/VectorTileFeature.h vector_tiles/VectorTileFeature.cpp
+        map_label/LabelFactory.h map_label/LabelFactory.cpp
+        map_label/MapLabelData.h
+    )
+    target_link_libraries(nucleus PUBLIC vector_tiles)
+endif()
 
 target_include_directories(nucleus PUBLIC ${CMAKE_SOURCE_DIR})
 # Please keep Qt::Gui outside the nucleus. If you need it optional via a cmake based switch
-target_link_libraries(nucleus PUBLIC radix Qt::Core Qt::Network fmt::fmt zppbits tl_expected nucleus_version stb_slim vector_tiles goofy_tc)
+target_link_libraries(nucleus PUBLIC radix Qt::Core Qt::Network fmt::fmt zppbits tl_expected nucleus_version stb_slim goofy_tc)
 
 qt_add_resources(nucleus "icons"
     PREFIX "/map_icons"

--- a/nucleus/CMakeLists.txt
+++ b/nucleus/CMakeLists.txt
@@ -123,6 +123,7 @@ if(ALP_ENABLE_LABELS)
         map_label/MapLabelData.h
     )
     target_link_libraries(nucleus PUBLIC vector_tiles)
+    target_compile_definitions(nucleus PUBLIC ALP_ENABLE_LABELS)
 endif()
 
 target_include_directories(nucleus PUBLIC ${CMAKE_SOURCE_DIR})

--- a/nucleus/Controller.cpp
+++ b/nucleus/Controller.cpp
@@ -40,7 +40,6 @@
 #include "radix/TileHeights.h"
 
 using namespace nucleus::tile_scheduler;
-using namespace nucleus::vectortile;
 
 namespace nucleus {
 Controller::Controller(AbstractRenderWindow* render_window)

--- a/nucleus/tile_scheduler/Scheduler.cpp
+++ b/nucleus/tile_scheduler/Scheduler.cpp
@@ -28,13 +28,15 @@
 #include <QStandardPaths>
 #include <QTimer>
 
+#include "nucleus/DataQuerier.h"
 #include "nucleus/tile_scheduler/utils.h"
 #include "nucleus/utils/image_loader.h"
 #include "nucleus/utils/tile_conversion.h"
-#include "nucleus/vector_tiles/VectorTileManager.h"
 #include "radix/quad_tree.h"
 
-#include "nucleus/DataQuerier.h"
+#ifdef ALP_ENABLE_LABELS
+#include "nucleus/vector_tiles/VectorTileManager.h"
+#endif
 
 using namespace nucleus::tile_scheduler;
 
@@ -197,11 +199,13 @@ void Scheduler::update_gpu_quads()
                                gpu_quad.tiles[i].height = std::make_shared<nucleus::Raster<uint16_t>>(std::move(heightraster));
                            }
 
+#ifdef ALP_ENABLE_LABELS
                            const auto* vectortile_data = m_default_vector_tile.get();
                            vectortile_data = quad.tiles[i].vector_tile.get();
                            // moved into this if -> since vector_tile might be empty
                            auto vectortile = nucleus::vectortile::VectorTileManager::to_vector_tile(quad.tiles[i].id, *vectortile_data, m_dataquerier);
                            gpu_quad.tiles[i].vector_tile = vectortile;
+#endif
                        }
                        return gpu_quad;
                    });

--- a/nucleus/tile_scheduler/tile_types.h
+++ b/nucleus/tile_scheduler/tile_types.h
@@ -22,8 +22,11 @@
 
 #include "nucleus/tile_scheduler/utils.h"
 #include "nucleus/utils/ColourTexture.h"
-#include <nucleus/vector_tiles/VectorTileFeature.h>
 #include <radix/tile.h>
+
+#ifdef ALP_ENABLE_LABELS
+#include <nucleus/vector_tiles/VectorTileFeature.h>
+#endif
 
 class QImage;
 namespace nucleus {
@@ -106,7 +109,10 @@ struct GpuLayeredTile {
     tile::SrsAndHeightBounds bounds = {};
     std::shared_ptr<const nucleus::utils::ColourTexture> ortho;
     std::shared_ptr<const nucleus::Raster<uint16_t>> height;
+
+#ifdef ALP_ENABLE_LABELS
     std::shared_ptr<const nucleus::vectortile::VectorTile> vector_tile;
+#endif
 };
 static_assert(NamedTile<GpuLayeredTile>);
 

--- a/unittests/nucleus/CMakeLists.txt
+++ b/unittests/nucleus/CMakeLists.txt
@@ -29,7 +29,6 @@ alp_add_unittest(unittests_nucleus
     test_srs.cpp
     test_track.cpp
     test_tile_conversion.cpp
-    test_vector_tile.cpp
     nucleus_tile_scheduler_util.cpp
     nucleus_tile_scheduler_tile_load_service.cpp
     nucleus_tile_scheduler_layer_assembler.cpp
@@ -48,6 +47,12 @@ if (ALP_ENABLE_AVLANCHE_WARNING_LAYER)
     target_sources(unittests_nucleus
       PRIVATE
         avalanche_warning_layer.cpp
+    )
+endif()
+
+if (ALP_ENABLE_LABELS)
+    target_sources(unittests_nucleus PRIVATE
+        test_vector_tile.cpp
     )
 endif()
 


### PR DESCRIPTION
Labels introduced a dependency to mapbox/variant that uses the function `std::result_of`, which was removed in C++20. While some compilers don't care as long as it is not actually used, unfortunately MSVC does care.

This PR introduces a CMake option to disable labels and thus side step compile issues with MSVC until a long-term solution is implemented (i.e. the deprecated dependency is removed).