### PR TITLE
rasterizer

### DIFF
--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -22,25 +22,22 @@ jobs:
       fail-fast: false
       matrix:
         qtarch: [wasm_singlethread, wasm_multithread, android_arm64_v8a, android_armv7]
+        qtversion: ['6.6.1']
         include:
           - qtarch: wasm_singlethread
             qttarget: 'desktop'
-            qtversion: '6.6.1'
             qtmodules: ''
             additional_build_flags: '--target install'
           - qtarch: wasm_multithread
             qttarget: 'desktop'
-            qtversion: '6.6.1'
             qtmodules: ''
             additional_cmake_flags: '-DALP_ENABLE_THREADING=ON'
             additional_build_flags: '--target install'
           - qtarch: android_arm64_v8a
             qttarget: 'android'
-            qtversion: '6.8.1'
             qtmodules: 'qtcharts qtpositioning'
           - qtarch: android_armv7
             qttarget: 'android'
-            qtversion: '6.8.1'
             qtmodules: 'qtcharts qtpositioning'
           
     steps:

--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -33,12 +33,12 @@ jobs:
             qtmodules: ''
             additional_cmake_flags: '-DALP_ENABLE_THREADING=ON'
             additional_build_flags: '--target install'
-          - qtarch: android_arm64_v8a
-            qttarget: 'android'
-            qtmodules: 'qtcharts qtpositioning'
-          - qtarch: android_armv7
-            qttarget: 'android'
-            qtmodules: 'qtcharts qtpositioning'
+          # - qtarch: android_arm64_v8a
+          #   qttarget: 'android'
+          #   qtmodules: 'qtcharts qtpositioning'
+          # - qtarch: android_armv7
+          #   qttarget: 'android'
+          #   qtmodules: 'qtcharts qtpositioning'
           
     steps:
     - name: Install dependencies

--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -33,12 +33,12 @@ jobs:
             qtmodules: ''
             additional_cmake_flags: '-DALP_ENABLE_THREADING=ON'
             additional_build_flags: '--target install'
-          # - qtarch: android_arm64_v8a
-          #   qttarget: 'android'
-          #   qtmodules: 'qtcharts qtpositioning'
-          # - qtarch: android_armv7
-          #   qttarget: 'android'
-          #   qtmodules: 'qtcharts qtpositioning'
+          - qtarch: android_arm64_v8a
+            qttarget: 'android'
+            qtmodules: 'qtcharts qtpositioning'
+          - qtarch: android_armv7
+            qttarget: 'android'
+            qtmodules: 'qtcharts qtpositioning'
           
     steps:
     - name: Install dependencies

--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -21,7 +21,7 @@ jobs:
     strategy:
       fail-fast: false
       matrix:
-        qtarch: [wasm_singlethread, wasm_multithread, android_arm64_v8a, android_armv7]
+        qtarch: [wasm_singlethread, wasm_multithread]
         qtversion: ['6.6.1']
         include:
           - qtarch: wasm_singlethread

--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -21,7 +21,7 @@ jobs:
     strategy:
       fail-fast: false
       matrix:
-        qtarch: [wasm_singlethread, wasm_multithread]
+        qtarch: [wasm_singlethread, wasm_multithread, android_arm64_v8a, android_armv7]
         qtversion: ['6.6.1']
         include:
           - qtarch: wasm_singlethread

--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -22,22 +22,25 @@ jobs:
       fail-fast: false
       matrix:
         qtarch: [wasm_singlethread, wasm_multithread, android_arm64_v8a, android_armv7]
-        qtversion: ['6.6.1']
         include:
           - qtarch: wasm_singlethread
             qttarget: 'desktop'
+            qtversion: '6.6.1'
             qtmodules: ''
             additional_build_flags: '--target install'
           - qtarch: wasm_multithread
             qttarget: 'desktop'
+            qtversion: '6.6.1'
             qtmodules: ''
             additional_cmake_flags: '-DALP_ENABLE_THREADING=ON'
             additional_build_flags: '--target install'
           - qtarch: android_arm64_v8a
             qttarget: 'android'
+            qtversion: '6.8.1'
             qtmodules: 'qtcharts qtpositioning'
           - qtarch: android_armv7
             qttarget: 'android'
+            qtversion: '6.8.1'
             qtmodules: 'qtcharts qtpositioning'
           
     steps:

--- a/nucleus/CMakeLists.txt
+++ b/nucleus/CMakeLists.txt
@@ -29,7 +29,7 @@ if(ALP_ENABLE_LABELS)
     alp_add_git_repository(vector_tiles URL https://github.com/AlpineMapsOrg/vector-tile.git COMMITISH faba88257716c4bc01ebd44d8b8b98f711ecb78c)
 endif()
 alp_add_git_repository(goofy_tc URL https://github.com/AlpineMapsOrgDependencies/Goofy_slim.git COMMITISH 13b228784960a6227bb6ca704ff34161bbac1b91 DO_NOT_ADD_SUBPROJECT)
-alp_add_git_repository(cdt URL https://github.com/artem-ogre/CDT.git COMMITISH 46f1ce1f495a97617d90e8c833d0d29406335fdf DO_NOT_ADD_SUBPROJECT)
+# alp_add_git_repository(cdt URL https://github.com/artem-ogre/CDT.git COMMITISH 46f1ce1f495a97617d90e8c833d0d29406335fdf DO_NOT_ADD_SUBPROJECT)
 
 add_library(zppbits INTERFACE)
 target_include_directories(zppbits SYSTEM INTERFACE ${zppbits_SOURCE_DIR})
@@ -41,8 +41,8 @@ set_target_properties(goofy_tc PROPERTIES SYSTEM true)
 add_library(tl_expected INTERFACE)
 target_include_directories(tl_expected INTERFACE ${tl_expected_SOURCE_DIR}/include)
 
-add_library(cdt INTERFACE)
-target_include_directories(cdt INTERFACE ${cdt_SOURCE_DIR}/CDT/include)
+# add_library(cdt INTERFACE)
+# target_include_directories(cdt INTERFACE ${cdt_SOURCE_DIR}/CDT/include)
 
 set(alp_version_out ${CMAKE_BINARY_DIR}/alp_version/nucleus/version.cpp)
 
@@ -149,7 +149,8 @@ endif()
 
 target_include_directories(nucleus PUBLIC ${CMAKE_SOURCE_DIR})
 # Please keep Qt::Gui outside the nucleus. If you need it optional via a cmake based switch
-target_link_libraries(nucleus PUBLIC radix Qt::Core Qt::Network zppbits tl_expected nucleus_version stb_slim goofy_tc cdt)
+target_link_libraries(nucleus PUBLIC radix Qt::Core Qt::Network zppbits tl_expected nucleus_version stb_slim goofy_tc)
+# target_link_libraries(nucleus PUBLIC radix Qt::Core Qt::Network zppbits tl_expected nucleus_version stb_slim goofy_tc cdt)
 
 qt_add_resources(nucleus "icons"
     PREFIX "/map_icons"

--- a/nucleus/CMakeLists.txt
+++ b/nucleus/CMakeLists.txt
@@ -29,6 +29,7 @@ if(ALP_ENABLE_LABELS)
     alp_add_git_repository(vector_tiles URL https://github.com/AlpineMapsOrg/vector-tile.git COMMITISH faba88257716c4bc01ebd44d8b8b98f711ecb78c)
 endif()
 alp_add_git_repository(goofy_tc URL https://github.com/AlpineMapsOrgDependencies/Goofy_slim.git COMMITISH 13b228784960a6227bb6ca704ff34161bbac1b91 DO_NOT_ADD_SUBPROJECT)
+alp_add_git_repository(cdt URL https://github.com/artem-ogre/CDT.git COMMITISH 46f1ce1f495a97617d90e8c833d0d29406335fdf DO_NOT_ADD_SUBPROJECT)
 
 add_library(zppbits INTERFACE)
 target_include_directories(zppbits SYSTEM INTERFACE ${zppbits_SOURCE_DIR})
@@ -39,6 +40,9 @@ set_target_properties(goofy_tc PROPERTIES SYSTEM true)
 
 add_library(tl_expected INTERFACE)
 target_include_directories(tl_expected INTERFACE ${tl_expected_SOURCE_DIR}/include)
+
+add_library(cdt INTERFACE)
+target_include_directories(cdt INTERFACE ${cdt_SOURCE_DIR}/CDT/include)
 
 set(alp_version_out ${CMAKE_BINARY_DIR}/alp_version/nucleus/version.cpp)
 
@@ -113,6 +117,7 @@ qt_add_library(nucleus STATIC
     tile/GeometryScheduler.h tile/GeometryScheduler.cpp
     utils/error.h
     utils/lang.h
+    utils/rasterizer.h utils/rasterizer.cpp
 )
 
 if (ALP_ENABLE_AVLANCHE_WARNING_LAYER)
@@ -144,7 +149,7 @@ endif()
 
 target_include_directories(nucleus PUBLIC ${CMAKE_SOURCE_DIR})
 # Please keep Qt::Gui outside the nucleus. If you need it optional via a cmake based switch
-target_link_libraries(nucleus PUBLIC radix Qt::Core Qt::Network zppbits tl_expected nucleus_version stb_slim goofy_tc)
+target_link_libraries(nucleus PUBLIC radix Qt::Core Qt::Network zppbits tl_expected nucleus_version stb_slim goofy_tc cdt)
 
 qt_add_resources(nucleus "icons"
     PREFIX "/map_icons"

--- a/nucleus/CMakeLists.txt
+++ b/nucleus/CMakeLists.txt
@@ -29,7 +29,7 @@ if(ALP_ENABLE_LABELS)
     alp_add_git_repository(vector_tiles URL https://github.com/AlpineMapsOrg/vector-tile.git COMMITISH faba88257716c4bc01ebd44d8b8b98f711ecb78c)
 endif()
 alp_add_git_repository(goofy_tc URL https://github.com/AlpineMapsOrgDependencies/Goofy_slim.git COMMITISH 13b228784960a6227bb6ca704ff34161bbac1b91 DO_NOT_ADD_SUBPROJECT)
-# alp_add_git_repository(cdt URL https://github.com/artem-ogre/CDT.git COMMITISH 46f1ce1f495a97617d90e8c833d0d29406335fdf DO_NOT_ADD_SUBPROJECT)
+alp_add_git_repository(cdt URL https://github.com/artem-ogre/CDT.git COMMITISH 46f1ce1f495a97617d90e8c833d0d29406335fdf DO_NOT_ADD_SUBPROJECT)
 
 add_library(zppbits INTERFACE)
 target_include_directories(zppbits SYSTEM INTERFACE ${zppbits_SOURCE_DIR})
@@ -41,8 +41,8 @@ set_target_properties(goofy_tc PROPERTIES SYSTEM true)
 add_library(tl_expected INTERFACE)
 target_include_directories(tl_expected INTERFACE ${tl_expected_SOURCE_DIR}/include)
 
-# add_library(cdt INTERFACE)
-# target_include_directories(cdt INTERFACE ${cdt_SOURCE_DIR}/CDT/include)
+add_library(cdt INTERFACE)
+target_include_directories(cdt INTERFACE ${cdt_SOURCE_DIR}/CDT/include)
 
 set(alp_version_out ${CMAKE_BINARY_DIR}/alp_version/nucleus/version.cpp)
 
@@ -149,8 +149,7 @@ endif()
 
 target_include_directories(nucleus PUBLIC ${CMAKE_SOURCE_DIR})
 # Please keep Qt::Gui outside the nucleus. If you need it optional via a cmake based switch
-target_link_libraries(nucleus PUBLIC radix Qt::Core Qt::Network zppbits tl_expected nucleus_version stb_slim goofy_tc)
-# target_link_libraries(nucleus PUBLIC radix Qt::Core Qt::Network zppbits tl_expected nucleus_version stb_slim goofy_tc cdt)
+target_link_libraries(nucleus PUBLIC radix Qt::Core Qt::Network zppbits tl_expected nucleus_version stb_slim goofy_tc cdt)
 
 qt_add_resources(nucleus "icons"
     PREFIX "/map_icons"

--- a/nucleus/tile/conversion.h
+++ b/nucleus/tile/conversion.h
@@ -107,4 +107,38 @@ inline glm::u8vec4 uint162alpineRGBA(uint16_t v)
 {
     return { v >> 8, v & 255, 0, 255 };
 }
+
+inline QImage u8raster_to_qimage(const nucleus::Raster<uint8_t>& raster)
+{
+    size_t width = raster.width();
+    size_t height = raster.height();
+
+    QImage image(width, height, QImage::Format_Grayscale8);
+
+    for (size_t y = 0; y < height; ++y) {
+        uchar* line = image.scanLine(y);
+        for (size_t x = 0; x < width; ++x) {
+            line[x] = raster.pixel({ x, y });
+        }
+    }
+
+    return image;
+}
+
+inline QImage u8raster_2_to_qimage(const nucleus::Raster<uint8_t>& raster1, const nucleus::Raster<uint8_t>& raster2)
+{
+    size_t width = raster1.width();
+    size_t height = raster1.height();
+
+    QImage image(width, height, QImage::Format_RGB888);
+
+    for (size_t y = 0; y < height; ++y) {
+        for (size_t x = 0; x < width; ++x) {
+            image.setPixel(QPoint(x, y), (raster1.pixel({ x, y }) << 16) + (raster2.pixel({ x, y }) << 8));
+        }
+    }
+
+    return image;
+}
+
 } // namespace nucleus::tile::conversion

--- a/nucleus/utils/rasterizer.cpp
+++ b/nucleus/utils/rasterizer.cpp
@@ -1,0 +1,85 @@
+/*****************************************************************************
+ * AlpineMaps.org
+ * Copyright (C) 2024 Lucas Dworschak
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with this program.  If not, see <http://www.gnu.org/licenses/>.
+ *****************************************************************************/
+
+#include "rasterizer.h"
+
+#include <CDT.h>
+
+namespace nucleus::utils::rasterizer {
+
+std::vector<glm::vec2> triangulize(std::vector<glm::vec2> polygons)
+{
+    std::vector<glm::vec2> processed_triangles;
+
+    std::vector<glm::ivec2> edges;
+    { // create the edges
+        edges.reserve(polygons.size());
+        for (size_t i = 0; i < polygons.size() - 1; i++) {
+            edges.push_back(glm::ivec2(int(i), int(i + 1)));
+        }
+
+        // last edge between start and end vertex
+        edges.push_back(glm::ivec2(polygons.size() - 1, 0));
+    }
+
+    // triangulation
+    CDT::Triangulation<double> cdt;
+    cdt.insertVertices(polygons.begin(), polygons.end(), [](const glm::vec2& p) { return p.x; }, [](const glm::vec2& p) { return p.y; });
+    cdt.insertEdges(edges.begin(), edges.end(), [](const glm::ivec2& p) { return p.x; }, [](const glm::ivec2& p) { return p.y; });
+    cdt.eraseOuterTrianglesAndHoles();
+
+    // fill our own data structures
+    for (size_t i = 0; i < cdt.triangles.size(); ++i) {
+        auto tri = cdt.triangles[i];
+
+        std::vector<size_t> tri_indices = { tri.vertices[0], tri.vertices[1], tri.vertices[2] };
+
+        int top_index = (cdt.vertices[tri.vertices[0]].y < cdt.vertices[tri.vertices[1]].y) ? ((cdt.vertices[tri.vertices[0]].y < cdt.vertices[tri.vertices[2]].y) ? 0 : 2)
+                                                                                            : ((cdt.vertices[tri.vertices[1]].y < cdt.vertices[tri.vertices[2]].y) ? 1 : 2);
+        // for middle and bottom index we first initialize them randomly with the values that still need to be tested
+        int middle_index;
+        int bottom_index;
+        if (top_index == 0) {
+            middle_index = 1;
+            bottom_index = 2;
+        } else if (top_index == 1) {
+            middle_index = 2;
+            bottom_index = 0;
+        } else {
+            middle_index = 0;
+            bottom_index = 1;
+        }
+
+        // and now we test if we assigned them correctly
+        if (cdt.vertices[tri.vertices[middle_index]].y > cdt.vertices[tri.vertices[bottom_index]].y) {
+            // if not we have to interchange them
+            int tmp = middle_index;
+            middle_index = bottom_index;
+            bottom_index = tmp;
+        }
+
+        // lastly add the vertices to the vector in the correct order
+        processed_triangles.push_back({ cdt.vertices[tri.vertices[top_index]].x, cdt.vertices[tri.vertices[top_index]].y });
+        processed_triangles.push_back({ cdt.vertices[tri.vertices[middle_index]].x, cdt.vertices[tri.vertices[middle_index]].y });
+        processed_triangles.push_back({ cdt.vertices[tri.vertices[bottom_index]].x, cdt.vertices[tri.vertices[bottom_index]].y });
+    }
+
+    return processed_triangles;
+}
+
+} // namespace nucleus::utils::rasterizer

--- a/nucleus/utils/rasterizer.cpp
+++ b/nucleus/utils/rasterizer.cpp
@@ -18,68 +18,68 @@
 
 #include "rasterizer.h"
 
-// #include <CDT.h>
+#include <CDT.h>
 
 namespace nucleus::utils::rasterizer {
 
-// std::vector<glm::vec2> triangulize(std::vector<glm::vec2> polygons)
-// {
-//     std::vector<glm::vec2> processed_triangles;
+std::vector<glm::vec2> triangulize(std::vector<glm::vec2> polygons)
+{
+    std::vector<glm::vec2> processed_triangles;
 
-//     std::vector<glm::ivec2> edges;
-//     { // create the edges
-//         edges.reserve(polygons.size());
-//         for (size_t i = 0; i < polygons.size() - 1; i++) {
-//             edges.push_back(glm::ivec2(int(i), int(i + 1)));
-//         }
+    std::vector<glm::ivec2> edges;
+    { // create the edges
+        edges.reserve(polygons.size());
+        for (size_t i = 0; i < polygons.size() - 1; i++) {
+            edges.push_back(glm::ivec2(int(i), int(i + 1)));
+        }
 
-//         // last edge between start and end vertex
-//         edges.push_back(glm::ivec2(polygons.size() - 1, 0));
-//     }
+        // last edge between start and end vertex
+        edges.push_back(glm::ivec2(polygons.size() - 1, 0));
+    }
 
-//     // triangulation
-//     CDT::Triangulation<double> cdt;
-//     cdt.insertVertices(polygons.begin(), polygons.end(), [](const glm::vec2& p) { return p.x; }, [](const glm::vec2& p) { return p.y; });
-//     cdt.insertEdges(edges.begin(), edges.end(), [](const glm::ivec2& p) { return p.x; }, [](const glm::ivec2& p) { return p.y; });
-//     cdt.eraseOuterTrianglesAndHoles();
+    // triangulation
+    CDT::Triangulation<double> cdt;
+    cdt.insertVertices(polygons.begin(), polygons.end(), [](const glm::vec2& p) { return p.x; }, [](const glm::vec2& p) { return p.y; });
+    cdt.insertEdges(edges.begin(), edges.end(), [](const glm::ivec2& p) { return p.x; }, [](const glm::ivec2& p) { return p.y; });
+    cdt.eraseOuterTrianglesAndHoles();
 
-//     // fill our own data structures
-//     for (size_t i = 0; i < cdt.triangles.size(); ++i) {
-//         auto tri = cdt.triangles[i];
+    // fill our own data structures
+    for (size_t i = 0; i < cdt.triangles.size(); ++i) {
+        auto tri = cdt.triangles[i];
 
-//         std::vector<size_t> tri_indices = { tri.vertices[0], tri.vertices[1], tri.vertices[2] };
+        std::vector<size_t> tri_indices = { tri.vertices[0], tri.vertices[1], tri.vertices[2] };
 
-//         int top_index = (cdt.vertices[tri.vertices[0]].y < cdt.vertices[tri.vertices[1]].y) ? ((cdt.vertices[tri.vertices[0]].y < cdt.vertices[tri.vertices[2]].y) ? 0 : 2)
-//                                                                                             : ((cdt.vertices[tri.vertices[1]].y < cdt.vertices[tri.vertices[2]].y) ? 1 : 2);
-//         // for middle and bottom index we first initialize them randomly with the values that still need to be tested
-//         int middle_index;
-//         int bottom_index;
-//         if (top_index == 0) {
-//             middle_index = 1;
-//             bottom_index = 2;
-//         } else if (top_index == 1) {
-//             middle_index = 2;
-//             bottom_index = 0;
-//         } else {
-//             middle_index = 0;
-//             bottom_index = 1;
-//         }
+        int top_index = (cdt.vertices[tri.vertices[0]].y < cdt.vertices[tri.vertices[1]].y) ? ((cdt.vertices[tri.vertices[0]].y < cdt.vertices[tri.vertices[2]].y) ? 0 : 2)
+                                                                                            : ((cdt.vertices[tri.vertices[1]].y < cdt.vertices[tri.vertices[2]].y) ? 1 : 2);
+        // for middle and bottom index we first initialize them randomly with the values that still need to be tested
+        int middle_index;
+        int bottom_index;
+        if (top_index == 0) {
+            middle_index = 1;
+            bottom_index = 2;
+        } else if (top_index == 1) {
+            middle_index = 2;
+            bottom_index = 0;
+        } else {
+            middle_index = 0;
+            bottom_index = 1;
+        }
 
-//         // and now we test if we assigned them correctly
-//         if (cdt.vertices[tri.vertices[middle_index]].y > cdt.vertices[tri.vertices[bottom_index]].y) {
-//             // if not we have to interchange them
-//             int tmp = middle_index;
-//             middle_index = bottom_index;
-//             bottom_index = tmp;
-//         }
+        // and now we test if we assigned them correctly
+        if (cdt.vertices[tri.vertices[middle_index]].y > cdt.vertices[tri.vertices[bottom_index]].y) {
+            // if not we have to interchange them
+            int tmp = middle_index;
+            middle_index = bottom_index;
+            bottom_index = tmp;
+        }
 
-//         // lastly add the vertices to the vector in the correct order
-//         processed_triangles.push_back({ cdt.vertices[tri.vertices[top_index]].x, cdt.vertices[tri.vertices[top_index]].y });
-//         processed_triangles.push_back({ cdt.vertices[tri.vertices[middle_index]].x, cdt.vertices[tri.vertices[middle_index]].y });
-//         processed_triangles.push_back({ cdt.vertices[tri.vertices[bottom_index]].x, cdt.vertices[tri.vertices[bottom_index]].y });
-//     }
+        // lastly add the vertices to the vector in the correct order
+        processed_triangles.push_back({ cdt.vertices[tri.vertices[top_index]].x, cdt.vertices[tri.vertices[top_index]].y });
+        processed_triangles.push_back({ cdt.vertices[tri.vertices[middle_index]].x, cdt.vertices[tri.vertices[middle_index]].y });
+        processed_triangles.push_back({ cdt.vertices[tri.vertices[bottom_index]].x, cdt.vertices[tri.vertices[bottom_index]].y });
+    }
 
-//     return processed_triangles;
-// }
+    return processed_triangles;
+}
 
 } // namespace nucleus::utils::rasterizer

--- a/nucleus/utils/rasterizer.cpp
+++ b/nucleus/utils/rasterizer.cpp
@@ -18,68 +18,68 @@
 
 #include "rasterizer.h"
 
-#include <CDT.h>
+// #include <CDT.h>
 
 namespace nucleus::utils::rasterizer {
 
-std::vector<glm::vec2> triangulize(std::vector<glm::vec2> polygons)
-{
-    std::vector<glm::vec2> processed_triangles;
+// std::vector<glm::vec2> triangulize(std::vector<glm::vec2> polygons)
+// {
+//     std::vector<glm::vec2> processed_triangles;
 
-    std::vector<glm::ivec2> edges;
-    { // create the edges
-        edges.reserve(polygons.size());
-        for (size_t i = 0; i < polygons.size() - 1; i++) {
-            edges.push_back(glm::ivec2(int(i), int(i + 1)));
-        }
+//     std::vector<glm::ivec2> edges;
+//     { // create the edges
+//         edges.reserve(polygons.size());
+//         for (size_t i = 0; i < polygons.size() - 1; i++) {
+//             edges.push_back(glm::ivec2(int(i), int(i + 1)));
+//         }
 
-        // last edge between start and end vertex
-        edges.push_back(glm::ivec2(polygons.size() - 1, 0));
-    }
+//         // last edge between start and end vertex
+//         edges.push_back(glm::ivec2(polygons.size() - 1, 0));
+//     }
 
-    // triangulation
-    CDT::Triangulation<double> cdt;
-    cdt.insertVertices(polygons.begin(), polygons.end(), [](const glm::vec2& p) { return p.x; }, [](const glm::vec2& p) { return p.y; });
-    cdt.insertEdges(edges.begin(), edges.end(), [](const glm::ivec2& p) { return p.x; }, [](const glm::ivec2& p) { return p.y; });
-    cdt.eraseOuterTrianglesAndHoles();
+//     // triangulation
+//     CDT::Triangulation<double> cdt;
+//     cdt.insertVertices(polygons.begin(), polygons.end(), [](const glm::vec2& p) { return p.x; }, [](const glm::vec2& p) { return p.y; });
+//     cdt.insertEdges(edges.begin(), edges.end(), [](const glm::ivec2& p) { return p.x; }, [](const glm::ivec2& p) { return p.y; });
+//     cdt.eraseOuterTrianglesAndHoles();
 
-    // fill our own data structures
-    for (size_t i = 0; i < cdt.triangles.size(); ++i) {
-        auto tri = cdt.triangles[i];
+//     // fill our own data structures
+//     for (size_t i = 0; i < cdt.triangles.size(); ++i) {
+//         auto tri = cdt.triangles[i];
 
-        std::vector<size_t> tri_indices = { tri.vertices[0], tri.vertices[1], tri.vertices[2] };
+//         std::vector<size_t> tri_indices = { tri.vertices[0], tri.vertices[1], tri.vertices[2] };
 
-        int top_index = (cdt.vertices[tri.vertices[0]].y < cdt.vertices[tri.vertices[1]].y) ? ((cdt.vertices[tri.vertices[0]].y < cdt.vertices[tri.vertices[2]].y) ? 0 : 2)
-                                                                                            : ((cdt.vertices[tri.vertices[1]].y < cdt.vertices[tri.vertices[2]].y) ? 1 : 2);
-        // for middle and bottom index we first initialize them randomly with the values that still need to be tested
-        int middle_index;
-        int bottom_index;
-        if (top_index == 0) {
-            middle_index = 1;
-            bottom_index = 2;
-        } else if (top_index == 1) {
-            middle_index = 2;
-            bottom_index = 0;
-        } else {
-            middle_index = 0;
-            bottom_index = 1;
-        }
+//         int top_index = (cdt.vertices[tri.vertices[0]].y < cdt.vertices[tri.vertices[1]].y) ? ((cdt.vertices[tri.vertices[0]].y < cdt.vertices[tri.vertices[2]].y) ? 0 : 2)
+//                                                                                             : ((cdt.vertices[tri.vertices[1]].y < cdt.vertices[tri.vertices[2]].y) ? 1 : 2);
+//         // for middle and bottom index we first initialize them randomly with the values that still need to be tested
+//         int middle_index;
+//         int bottom_index;
+//         if (top_index == 0) {
+//             middle_index = 1;
+//             bottom_index = 2;
+//         } else if (top_index == 1) {
+//             middle_index = 2;
+//             bottom_index = 0;
+//         } else {
+//             middle_index = 0;
+//             bottom_index = 1;
+//         }
 
-        // and now we test if we assigned them correctly
-        if (cdt.vertices[tri.vertices[middle_index]].y > cdt.vertices[tri.vertices[bottom_index]].y) {
-            // if not we have to interchange them
-            int tmp = middle_index;
-            middle_index = bottom_index;
-            bottom_index = tmp;
-        }
+//         // and now we test if we assigned them correctly
+//         if (cdt.vertices[tri.vertices[middle_index]].y > cdt.vertices[tri.vertices[bottom_index]].y) {
+//             // if not we have to interchange them
+//             int tmp = middle_index;
+//             middle_index = bottom_index;
+//             bottom_index = tmp;
+//         }
 
-        // lastly add the vertices to the vector in the correct order
-        processed_triangles.push_back({ cdt.vertices[tri.vertices[top_index]].x, cdt.vertices[tri.vertices[top_index]].y });
-        processed_triangles.push_back({ cdt.vertices[tri.vertices[middle_index]].x, cdt.vertices[tri.vertices[middle_index]].y });
-        processed_triangles.push_back({ cdt.vertices[tri.vertices[bottom_index]].x, cdt.vertices[tri.vertices[bottom_index]].y });
-    }
+//         // lastly add the vertices to the vector in the correct order
+//         processed_triangles.push_back({ cdt.vertices[tri.vertices[top_index]].x, cdt.vertices[tri.vertices[top_index]].y });
+//         processed_triangles.push_back({ cdt.vertices[tri.vertices[middle_index]].x, cdt.vertices[tri.vertices[middle_index]].y });
+//         processed_triangles.push_back({ cdt.vertices[tri.vertices[bottom_index]].x, cdt.vertices[tri.vertices[bottom_index]].y });
+//     }
 
-    return processed_triangles;
-}
+//     return processed_triangles;
+// }
 
 } // namespace nucleus::utils::rasterizer

--- a/nucleus/utils/rasterizer.h
+++ b/nucleus/utils/rasterizer.h
@@ -17,52 +17,65 @@
  *****************************************************************************/
 
 #include <array>
-#include <iostream>
 #include <vector>
 
 #include <glm/glm.hpp>
 
 namespace nucleus::utils::rasterizer {
 
-// Possible future improvements:
-// - DDA -> prevent fill_inner_triangle to be called twice for the same row (if we switch from one line to another)
-//      - also check overall how often each pixel is written to
+/*
+ * Possible future improvements:
+ *      - check how often each pixel is written to -> maybe we can improve performance here
+ *      - sdf box filter instead by circle to only consider values of the current cell
+ *      - calculate_dda_steps currently doubles the steps to prevent missing certain pixels (this might be improved)
+ */
 
 // TODOs:
-// - enlarge triangles
-//      - current problem: narrow triangles
 // - line renderer
-// sdf box filter instead by circle to only consider values of the current cell
 
 namespace details {
 
-    inline float get_x_for_y_on_line(const glm::vec2 origin, const glm::vec2 line, float y)
+    /*
+     * Calculates the x value for a given y.
+     * The resulting x value will be on the line.
+     */
+    inline float get_x_for_y_on_line(const glm::vec2 point_on_line, const glm::vec2 line, float y)
     {
-        // pos_on_line = origin + t * line
-        float t = (y - origin.y) / line.y;
+        // pos_on_line = point_on_line + t * line
+        float t = (y - point_on_line.y) / line.y;
 
-        return origin.x + t * line.x;
+        return point_on_line.x + t * line.x;
     }
 
+    /*
+     * Calculates the steps and step_size of the given line.
+     * the "bigger dimension" (-> line is bigger in x or y direction) has a step size of 0.5
+     * the other dimension has a step size <= 0.5
+     */
     inline std::pair<glm::vec2, int> calculate_dda_steps(const glm::vec2 line)
     {
-        int steps = ceil(fabs(line.x) > fabs(line.y) ? fabs(line.x) : fabs(line.y));
-        // should only be triggered if two vertices of a triangle are exactly on the same position
-        // -> the input data is wrong
+        float steps = fabs(line.x) > fabs(line.y) ? fabs(line.x) : fabs(line.y);
+
+        // should only be triggered if two vertices of a triangle are exactly on the same position -> the input data is wrong
         assert(steps > 0);
         // steps = std::max(steps, 1); // alternative force at least one dda step -> wrong output but it should at least "work"
 
         auto step_size = glm::vec2(line.x / float(steps), line.y / float(steps));
 
-        // double the steps -> otherwise we might miss important pixels
+        // double the steps -> otherwise we might miss important pixels ( see "rasterize triangle small" unittest for use case)
+        // it might be possible to capture the special cases during the line traversal and render an extra pixel
+        // -> possible performance improvement
         steps *= 2;
         step_size /= 2.0f;
 
-        return std::make_pair(step_size, steps);
+        return std::make_pair(step_size, ceil(steps));
     }
 
+    /*
+     * fills a scan line from current position to x position of given other line
+     */
     template <typename PixelWriterFunction>
-    inline void fill_inner_triangle(const PixelWriterFunction& pixel_writer, const glm::vec2& current_position, const glm::vec2& other_point, const glm::vec2& other_line, unsigned int data_index)
+    inline void fill_to_line(const PixelWriterFunction& pixel_writer, const glm::vec2& current_position, const glm::vec2& other_point, const glm::vec2& other_line, unsigned int data_index)
     {
         // calculate the x value of the other line
         int x = get_x_for_y_on_line(other_point, other_line, current_position.y);
@@ -74,23 +87,23 @@ namespace details {
         }
     }
 
-    // pixel_writer, topmost_renderable_point, top_bisector,
-    // enlarged_top_bottom_origin, edge_top_bottom,
-    // enlarged_top_middle_origin, edge_top_middle, triangle_index
+    /*
+     * applies dda algorithm to the given line and fills the area in between this line and the given other line
+     * if the other line is not located on the current scan line -> we fill to the given fall back lines
+     */
     template <typename PixelWriterFunction>
-    void dda_triangle_line(const PixelWriterFunction& pixel_writer,
+    void dda_render_line(const PixelWriterFunction& pixel_writer,
         unsigned int data_index,
         const glm::vec2& line_start,
         const glm::vec2& line,
-        const glm::vec2& other_point,
-        const glm::vec2& other_line,
-        const glm::vec2& normal_line = { 0, 0 },
+        const glm::vec2& other_point = { 0, 0 },
+        const glm::vec2& other_line = { 0, 0 },
+        const glm::vec2& normal_line = { 0, 0 }, // TODO possible to change this to a bool?
         const glm::vec2& fallback_point_upper = { 0, 0 },
         const glm::vec2& fallback_line_upper = { 0, 0 },
         const glm::vec2& fallback_point_lower = { 0, 0 },
         const glm::vec2& fallback_line_lower = { 0, 0 })
     {
-
         glm::vec2 step_size;
         int steps;
         std::tie(step_size, steps) = calculate_dda_steps(line);
@@ -98,21 +111,22 @@ namespace details {
         int last_y = 0;
 
         const bool is_enlarged_triangle = normal_line != glm::vec2 { 0, 0 };
+        const bool fill = other_line != glm::vec2 { 0, 0 }; // no other line given? -> no fill needed
 
         glm::vec2 current_position = line_start;
 
         for (int j = 0; j < steps; j++) {
             pixel_writer(current_position, data_index);
 
-            if (int(current_position.y + step_size.y) > current_position.y) { // next step would go to next y value
+            if (fill && int(current_position.y + step_size.y) > current_position.y) { // next step would go to next y value
 
                 // decide whether or not to fill only to the fallback line
                 if (is_enlarged_triangle && (current_position.y > other_point.y + other_line.y))
-                    fill_inner_triangle(pixel_writer, current_position, fallback_point_upper, fallback_line_upper, data_index);
+                    fill_to_line(pixel_writer, current_position, fallback_point_upper, fallback_line_upper, data_index);
                 else if (is_enlarged_triangle && (current_position.y < other_point.y))
-                    fill_inner_triangle(pixel_writer, current_position, fallback_point_lower, fallback_line_lower, data_index);
+                    fill_to_line(pixel_writer, current_position, fallback_point_lower, fallback_line_lower, data_index);
                 else // normal fill operation
-                    fill_inner_triangle(pixel_writer, current_position, other_point, other_line, data_index);
+                    fill_to_line(pixel_writer, current_position, other_point, other_line, data_index);
 
                 last_y = current_position.y;
             }
@@ -121,19 +135,22 @@ namespace details {
 
         current_position -= step_size;
 
-        // check if we have to apply the fill_inner_triangle alg for the current row
-        if (last_y != floor(current_position.y)) {
+        // check if we have to apply the fill_to_line alg for the current row
+        if (fill && last_y != floor(current_position.y)) {
             // fill only to the fallback line
             if (is_enlarged_triangle && (current_position.y > other_point.y + other_line.y))
-                fill_inner_triangle(pixel_writer, current_position, fallback_point_upper, fallback_line_upper, data_index);
+                fill_to_line(pixel_writer, current_position, fallback_point_upper, fallback_line_upper, data_index);
             else if (is_enlarged_triangle && (current_position.y < other_point.y))
-                fill_inner_triangle(pixel_writer, current_position, fallback_point_lower, fallback_line_lower, data_index);
+                fill_to_line(pixel_writer, current_position, fallback_point_lower, fallback_line_lower, data_index);
             else // normal fill operation
-                fill_inner_triangle(pixel_writer, current_position, other_point, other_line, data_index);
+                fill_to_line(pixel_writer, current_position, other_point, other_line, data_index);
         }
     }
 
-    template <typename PixelWriterFunction> void add_end_cap(const PixelWriterFunction& pixel_writer, const glm::vec2 position, unsigned int data_index, float distance)
+    /*
+     * renders a circle at the given position
+     */
+    template <typename PixelWriterFunction> void add_circle_end_cap(const PixelWriterFunction& pixel_writer, const glm::vec2 position, unsigned int data_index, float distance)
     {
         distance += sqrt(0.5);
         float distance_test = ceil(distance);
@@ -147,41 +164,42 @@ namespace details {
         }
     }
 
-    template <typename PixelWriterFunction> void dda_triangle(const PixelWriterFunction& pixel_writer, const std::vector<glm::vec2>& triangle, unsigned int triangle_index)
+    /*
+     * In order to process enlarged triangles, the triangle is separated into 3 parts: top, middle and bottom
+     * we first generate the normals for each edge and offset the triangle origins by the normal multiplied by the supplied distance to get 6 "enlarged" points that define the bigger triangle
+     *
+     * top / bottom part:
+     * the top and bottom part of the triangle are rendered by going through each y step of the line with the shorter y value and filling the inner triangle until it reaches the other side of the
+     * triangle for the very top and very bottom of the triangle special considerations have to be done, otherwise we would render too much if the line on the other side of the triangle is not hit
+     * during a fill operation (= we want to fill above or below the line segment), we use the normal of the current line as the bound for the fill operation
+     *
+     * for the middle part:
+     * if we enlarge the triangle by moving the edge along an edge normal we generate a gap between the top-middle and middle-bottom edge (since those lines are only translated)
+     * we have to somehow rasterize this gap between the bottom vertice of the translated top-middle edge and the top vertice of the middle-bottom edge.
+     * in order to do this we draw a new edge between those vertices and rasterize everything between this new edge and the top-bottom edge.
+     *
+     * lastly we have to add endcaps on each original vertice position with the given distance
+     */
+    template <typename PixelWriterFunction> void dda_triangle(const PixelWriterFunction& pixel_writer, const std::array<glm::vec2, 3> triangle, unsigned int triangle_index, float distance)
     {
+
+        assert(triangle[0].y <= triangle[1].y);
+        assert(triangle[1].y <= triangle[2].y);
+
         auto edge_top_bottom = triangle[2] - triangle[0];
         auto edge_top_middle = triangle[1] - triangle[0];
         auto edge_middle_bottom = triangle[2] - triangle[1];
 
-        // top middle
-        dda_triangle_line(pixel_writer, triangle_index, triangle[0], edge_top_middle, triangle[0], edge_top_bottom);
-        // middle bottom
-        dda_triangle_line(pixel_writer, triangle_index, triangle[1], edge_middle_bottom, triangle[0], edge_top_bottom);
-    }
+        if (distance == 0.0) {
+            // top middle
+            dda_render_line(pixel_writer, triangle_index, triangle[0], edge_top_middle, triangle[0], edge_top_bottom);
+            // middle bottom
+            dda_render_line(pixel_writer, triangle_index, triangle[1], edge_middle_bottom, triangle[0], edge_top_bottom);
 
-    template <typename PixelWriterFunction> void dda_triangle(const PixelWriterFunction& pixel_writer, const std::vector<glm::vec2>& triangle, unsigned int triangle_index, float distance)
-    {
-        // In order to process enlarged triangles, the triangle is separated into 3 parts: top, middle and bottom
-        // we first generate the normals for each edge and offset the triangle origins by the normal multiplied by the supplied distance to get 6 "enlarged" points that define the bigger triangle
+            return; // finished
+        }
 
-        // top / bottom part:
-        // the top and bottom part of the triangle are rendered by going through each y step of the line with the shorter y value and filling the inner triangle until it reaches the other side of the
-        // triangle for the very top and very bottom of the triangle special considerations have to be done, otherwise we would render too much if the line on the other side of the triangle is not hit
-        // during a fill operation (= we want to fill above or below the line segment), we use the normal of the current line as the bound for the fill operation
-
-        // for the middle part:
-        // if we enlarge the triangle by moving the edge along an edge normal we generate a gap between the top-middle and middle-bottom edge (since those lines are only translated)
-        // we have to somehow rasterize this gap between the bottom vertice of the translated top-middle edge and the top vertice of the middle-bottom edge.
-        // in order to do this we draw a new edge between those vertices and rasterize everything between this new edge and the top-bottom edge.
-
-        // lastly we have to add endcaps on each original vertice position with the given distance
-
-        // in the worst case here we have one triangle line that is paralell to scan line
-        // in this case it might be that we still have to consider that we are writing outside of the actual triangle !!!! -> find a solution!!!
-
-        auto edge_top_bottom = triangle[2] - triangle[0];
-        auto edge_top_middle = triangle[1] - triangle[0];
-        auto edge_middle_bottom = triangle[2] - triangle[1];
+        // we need to render an enlarged triangle
 
         auto normal_top_bottom = glm::normalize(glm::vec2(-edge_top_bottom.y, edge_top_bottom.x));
         auto normal_top_middle = glm::normalize(glm::vec2(-edge_top_middle.y, edge_top_middle.x));
@@ -210,7 +228,7 @@ namespace details {
         auto enlarged_middle_bottom_end = triangle[2] + normal_middle_bottom * distance;
 
         // top middle
-        dda_triangle_line(pixel_writer,
+        dda_render_line(pixel_writer,
             triangle_index,
             enlarged_top_middle_origin,
             edge_top_middle,
@@ -222,10 +240,10 @@ namespace details {
             enlarged_top_middle_origin,
             normal_top_middle);
 
-        // middle_top_part to middle_bottom_part
+        // // middle_top_part to middle_bottom_part
         auto half_middle_line = (enlarged_middle_bottom_origin - enlarged_top_middle_end) / glm::vec2(2.0);
 
-        dda_triangle_line(pixel_writer,
+        dda_render_line(pixel_writer,
             triangle_index,
             enlarged_top_middle_end,
             half_middle_line,
@@ -236,7 +254,7 @@ namespace details {
             normal_middle_bottom,
             enlarged_top_middle_origin,
             normal_top_middle);
-        dda_triangle_line(pixel_writer,
+        dda_render_line(pixel_writer,
             triangle_index,
             enlarged_top_middle_end + half_middle_line,
             half_middle_line,
@@ -249,7 +267,7 @@ namespace details {
             normal_top_middle);
 
         // middle bottom
-        dda_triangle_line(pixel_writer,
+        dda_render_line(pixel_writer,
             triangle_index,
             enlarged_middle_bottom_origin,
             edge_middle_bottom,
@@ -262,9 +280,9 @@ namespace details {
             normal_top_middle);
 
         // endcaps
-        add_end_cap(pixel_writer, triangle[0], triangle_index, distance);
-        add_end_cap(pixel_writer, triangle[1], triangle_index, distance);
-        add_end_cap(pixel_writer, triangle[2], triangle_index, distance);
+        add_circle_end_cap(pixel_writer, triangle[0], triangle_index, distance);
+        add_circle_end_cap(pixel_writer, triangle[1], triangle_index, distance);
+        add_circle_end_cap(pixel_writer, triangle[2], triangle_index, distance);
 
         // { // DEBUG visualize enlarged points
         //     auto enlarged_top_bottom_end = triangle[2] + normal_top_bottom * distance;
@@ -282,20 +300,157 @@ namespace details {
         // }
     }
 
-    template <typename PixelWriterFunction>
-    void triangle_sdf(const PixelWriterFunction& pixel_writer, const glm::vec2 current_position, const std::array<glm::vec2, 3> points, unsigned int data_index, float distance)
+    template <typename PixelWriterFunction> void dda_line(const PixelWriterFunction& pixel_writer, const std::array<glm::vec2, 2> line_points, unsigned int line_index, float distance)
     {
-        // https://iquilezles.org/articles/distfunctions2d/
+        // edge from top to bottom
+        glm::vec2 origin;
+        glm::vec2 edge;
+        if (line_points[0].y > line_points[1].y) {
+            edge = line_points[0] - line_points[1];
+            origin = line_points[1];
+        } else {
+            edge = line_points[1] - line_points[0];
+            origin = line_points[0];
+        }
 
-        glm::vec2 e0 = points[1] - points[0], e1 = points[2] - points[1], e2 = points[0] - points[2];
-        float s = glm::sign(e0.x * e2.y - e0.y * e2.x);
+        if (distance == 0.0) {
+            dda_render_line(pixel_writer, line_index, origin, edge);
+
+            pixel_writer(line_points[0], 50);
+            pixel_writer(line_points[1], 50);
+
+            return; // finished
+        }
+
+        // we need to render an enlarged triangle
+
+        // auto normal_top_bottom = glm::normalize(glm::vec2(-edge_top_bottom.y, edge_top_bottom.x));
+        // auto normal_top_middle = glm::normalize(glm::vec2(-edge_top_middle.y, edge_top_middle.x));
+        // auto normal_middle_bottom = glm::normalize(glm::vec2(-edge_middle_bottom.y, edge_middle_bottom.x));
+
+        // { // swap normal direction if they are incorrect (pointing to center)
+        //     glm::vec2 centroid = (triangle[0] + triangle[1] + triangle[2]) / 3.0f;
+        //     if (glm::dot(normal_top_bottom, centroid - triangle[0]) > 0) {
+        //         normal_top_bottom *= -1;
+        //     }
+        //     if (glm::dot(normal_top_middle, centroid - triangle[0]) > 0) {
+        //         normal_top_middle *= -1;
+        //     }
+        //     if (glm::dot(normal_middle_bottom, centroid - triangle[1]) > 0) {
+        //         normal_middle_bottom *= -1;
+        //     }
+        // }
+
+        // auto enlarged_top_bottom_origin = triangle[0] + normal_top_bottom * distance;
+        // // auto enlarged_top_bottom_end = triangle[2] + normal_top_bottom * distance; // not needed
+
+        // auto enlarged_top_middle_origin = triangle[0] + normal_top_middle * distance;
+        // auto enlarged_top_middle_end = triangle[1] + normal_top_middle * distance;
+
+        // auto enlarged_middle_bottom_origin = triangle[1] + normal_middle_bottom * distance;
+        // auto enlarged_middle_bottom_end = triangle[2] + normal_middle_bottom * distance;
+
+        // // top middle
+        // dda_render_line(pixel_writer,
+        //     line_index,
+        //     enlarged_top_middle_origin,
+        //     edge_top_middle,
+        //     enlarged_top_bottom_origin,
+        //     edge_top_bottom,
+        //     normal_top_middle,
+        //     enlarged_middle_bottom_end,
+        //     normal_middle_bottom,
+        //     enlarged_top_middle_origin,
+        //     normal_top_middle);
+
+        // // // middle_top_part to middle_bottom_part
+        // auto half_middle_line = (enlarged_middle_bottom_origin - enlarged_top_middle_end) / glm::vec2(2.0);
+
+        // dda_render_line(pixel_writer,
+        //     line_index,
+        //     enlarged_top_middle_end,
+        //     half_middle_line,
+        //     enlarged_top_bottom_origin,
+        //     edge_top_bottom,
+        //     normal_top_middle,
+        //     enlarged_middle_bottom_end,
+        //     normal_middle_bottom,
+        //     enlarged_top_middle_origin,
+        //     normal_top_middle);
+        // dda_render_line(pixel_writer,
+        //     line_index,
+        //     enlarged_top_middle_end + half_middle_line,
+        //     half_middle_line,
+        //     enlarged_top_bottom_origin,
+        //     edge_top_bottom,
+        //     normal_middle_bottom,
+        //     enlarged_middle_bottom_end,
+        //     normal_middle_bottom,
+        //     enlarged_top_middle_origin,
+        //     normal_top_middle);
+
+        // // middle bottom
+        // dda_render_line(pixel_writer,
+        //     line_index,
+        //     enlarged_middle_bottom_origin,
+        //     edge_middle_bottom,
+        //     enlarged_top_bottom_origin,
+        //     edge_top_bottom,
+        //     normal_middle_bottom,
+        //     enlarged_middle_bottom_end,
+        //     normal_middle_bottom,
+        //     enlarged_top_middle_origin,
+        //     normal_top_middle);
+
+        // // endcaps
+        // add_circle_end_cap(pixel_writer, triangle[0], line_index, distance);
+        // add_circle_end_cap(pixel_writer, triangle[1], line_index, distance);
+        // add_circle_end_cap(pixel_writer, triangle[2], line_index, distance);
+
+        // { // DEBUG visualize enlarged points
+        //     auto enlarged_top_bottom_end = triangle[2] + normal_top_bottom * distance;
+        //     pixel_writer(triangle[0], 50);
+        //     pixel_writer(enlarged_top_bottom_origin, 50);
+        //     pixel_writer(enlarged_top_middle_origin, 50);
+
+        //     pixel_writer(triangle[1], 50);
+        //     pixel_writer(enlarged_middle_bottom_origin, 50);
+        //     pixel_writer(enlarged_top_middle_end, 50);
+
+        //     pixel_writer(triangle[2], 50);
+        //     pixel_writer(enlarged_middle_bottom_end, 50);
+        //     pixel_writer(enlarged_top_bottom_end, 50);
+        // }
+    }
+
+    /*
+     * calculates how far away the given position is from a triangle
+     * uses distance to shift the current triangle distance
+     * if it is within the triangle, the pixel writer function is called
+     *
+     * uses triangle distance calculation from: https://iquilezles.org/articles/distfunctions2d/
+     */
+    template <typename PixelWriterFunction>
+    void triangle_sdf(const PixelWriterFunction& pixel_writer,
+        const glm::vec2 current_position,
+        const std::array<glm::vec2, 3> points,
+        const std::array<glm::vec2, 3> edges,
+        float s,
+        unsigned int data_index,
+        float distance)
+    {
+        //
 
         glm::vec2 v0 = current_position - points[0], v1 = current_position - points[1], v2 = current_position - points[2];
-        glm::vec2 pq0 = v0 - e0 * glm::clamp(glm::dot(v0, e0) / glm::dot(e0, e0), 0.0f, 1.0f);
-        glm::vec2 pq1 = v1 - e1 * glm::clamp(glm::dot(v1, e1) / glm::dot(e1, e1), 0.0f, 1.0f);
-        glm::vec2 pq2 = v2 - e2 * glm::clamp(glm::dot(v2, e2) / glm::dot(e2, e2), 0.0f, 1.0f);
-        glm::vec2 d
-            = min(min(glm::vec2(dot(pq0, pq0), s * (v0.x * e0.y - v0.y * e0.x)), glm::vec2(dot(pq1, pq1), s * (v1.x * e1.y - v1.y * e1.x))), glm::vec2(dot(pq2, pq2), s * (v2.x * e2.y - v2.y * e2.x)));
+
+        // pq# = distance from edge #
+        glm::vec2 pq0 = v0 - edges[0] * glm::clamp(glm::dot(v0, edges[0]) / glm::dot(edges[0], edges[0]), 0.0f, 1.0f);
+        glm::vec2 pq1 = v1 - edges[1] * glm::clamp(glm::dot(v1, edges[1]) / glm::dot(edges[1], edges[1]), 0.0f, 1.0f);
+        glm::vec2 pq2 = v2 - edges[2] * glm::clamp(glm::dot(v2, edges[2]) / glm::dot(edges[2], edges[2]), 0.0f, 1.0f);
+        // d.x == squared distance to triangle edge/vertice
+        // d.y == are we inside or outside triangle
+        glm::vec2 d = min(min(glm::vec2(dot(pq0, pq0), s * (v0.x * edges[0].y - v0.y * edges[0].x)), glm::vec2(dot(pq1, pq1), s * (v1.x * edges[1].y - v1.y * edges[1].x))),
+            glm::vec2(dot(pq2, pq2), s * (v2.x * edges[2].y - v2.y * edges[2].x)));
         float dist_from_tri = -sqrt(d.x) * glm::sign(d.y);
 
         if (dist_from_tri < distance) {
@@ -303,45 +458,103 @@ namespace details {
         }
     }
 
+    /*
+     * calculates how far away the given position is from a line segment
+     * uses distance to shift the current triangle distance
+     * if it is within the triangle, the pixel writer function is called
+     *
+     * uses line segment distance calculation from: https://iquilezles.org/articles/distfunctions2d/
+     */
+    template <typename PixelWriterFunction>
+    void line_sdf(const PixelWriterFunction& pixel_writer, const glm::vec2 current_position, const glm::vec2 origin, glm::vec2 edge, unsigned int data_index, float distance)
+    {
+        glm::vec2 v0 = current_position - origin;
+
+        float dist_from_line = length(v0 - edge * glm::clamp(glm::dot(v0, edge) / glm::dot(edge, edge), 0.0f, 1.0f));
+
+        if (dist_from_line < distance) {
+            pixel_writer(current_position, data_index);
+        }
+    }
+
 } // namespace details
 
-// triangulizes polygons and orders the vertices by y position per triangle
-// output: top, middle, bottom, top, middle,...
+/*
+ * triangulizes polygons and orders the vertices by y position per triangle
+ * output: top, middle, bottom, top, middle,...
+ */
 std::vector<glm::vec2> triangulize(std::vector<glm::vec2> polygons);
 
-// ideal if you want to rasterize only a few triangles, where every triangle covers a large part of the raster size
-// in this method every pixel traverses every triangle
-template <typename PixelWriterFunction> void rasterize_triangle_sdf(const PixelWriterFunction& pixel_writer, const std::vector<glm::vec2>& triangles, float distance, const glm::ivec2 grid_size)
+/*
+ * ideal if you want to rasterize only a few triangles, where every triangle covers a large part of the raster size
+ * in this method we traverse through every triangle and generate the bounding box and traverse the bounding box
+ */
+template <typename PixelWriterFunction> void rasterize_triangle_sdf(const PixelWriterFunction& pixel_writer, const std::vector<glm::vec2>& triangles, float distance)
 {
     // we sample from the center
     // and have a radius of a half pixel diagonal
-    // this still leads to false positives if the edge of a triangle is slighly in another pixel without every comming in this pixel
+    // NOTICE: this still leads to false positives if the edge of a triangle is slighly in another pixel without every comming in this pixel!!
     distance += sqrt(0.5);
 
-    for (uint8_t i = 0; i < grid_size.x; i++) {
-        for (uint8_t j = 0; j < grid_size.y; j++) {
-            auto current_position = glm::vec2 { i + 0.5, j + 0.5 };
+    for (size_t i = 0; i < triangles.size() / 3; ++i) {
+        const std::array<glm::vec2, 3> points = { triangles[i * 3 + 0], triangles[i * 3 + 1], triangles[i * 3 + 2] };
+        const std::array<glm::vec2, 3> edges = { points[1] - points[0], points[2] - points[1], points[0] - points[2] };
 
-            for (size_t i = 0; i < triangles.size() / 3; ++i) {
-                details::triangle_sdf(pixel_writer, current_position, { triangles[i * 3 + 0], triangles[i * 3 + 1], triangles[i * 3 + 2] }, i, distance);
+        auto min_bound = min(min(points[0], points[1]), points[2]) - glm::vec2(distance);
+        auto max_bound = max(max(points[0], points[1]), points[2]) + glm::vec2(distance);
+
+        float s = glm::sign(edges[0].x * edges[2].y - edges[0].y * edges[2].x);
+
+        for (size_t x = min_bound.x; x < max_bound.x; x++) {
+            for (size_t y = min_bound.y; y < max_bound.y; y++) {
+                auto current_position = glm::vec2 { x + 0.5, y + 0.5 };
+
+                details::triangle_sdf(pixel_writer, current_position, points, edges, s, i, distance);
             }
         }
     }
 }
 
-// ideal for many triangles. especially if each triangle only covers small parts of the raster
-// in this method every triangle is traversed only once, and it only accesses pixels it needs for itself.
-template <typename PixelWriterFunction> void rasterize_triangle(const PixelWriterFunction& pixel_writer, const std::vector<glm::vec2>& triangles, float distance = 0.0)
+template <typename PixelWriterFunction> void rasterize_line_sdf(const PixelWriterFunction& pixel_writer, const std::vector<glm::vec2>& line_points, float distance)
 {
-    for (size_t i = 0; i < triangles.size() / 3; ++i) {
-        if (distance == 0.0)
-            details::dda_triangle(pixel_writer, { triangles[i * 3 + 0], triangles[i * 3 + 1], triangles[i * 3 + 2] }, i);
-        else
-            details::dda_triangle(pixel_writer, { triangles[i * 3 + 0], triangles[i * 3 + 1], triangles[i * 3 + 2] }, i, distance);
+    // we sample from the center
+    // and have a radius of a half pixel diagonal
+    // NOTICE: this still leads to false positives if the edge of a triangle is slighly in another pixel without every comming in this pixel!!
+    distance += sqrt(0.5);
+
+    for (size_t i = 0; i < line_points.size() - 1; ++i) {
+        const std::array<glm::vec2, 2> points = { line_points[i + 0], line_points[i + 1] };
+        auto edge = points[1] - points[0];
+
+        auto min_bound = min(points[0], points[1]) - glm::vec2(distance);
+        auto max_bound = max(points[0], points[1]) + glm::vec2(distance);
+
+        for (size_t x = min_bound.x; x < max_bound.x; x++) {
+            for (size_t y = min_bound.y; y < max_bound.y; y++) {
+                auto current_position = glm::vec2 { x + 0.5, y + 0.5 };
+
+                details::line_sdf(pixel_writer, current_position, points[0], edge, i, distance);
+            }
+        }
     }
 }
 
-// template <typename PixelWriterFunction>
-// void rasterize_line(const PixelWriterFunction& pixel_writer, std::vector<glm::vec2> line_points);
+/*
+ * ideal for many triangles. especially if each triangle only covers small parts of the raster
+ * in this method every triangle is traversed only once, and it only accesses pixels it needs for itself.
+ */
+template <typename PixelWriterFunction> void rasterize_triangle(const PixelWriterFunction& pixel_writer, const std::vector<glm::vec2>& triangles, float distance = 0.0)
+{
+    for (size_t i = 0; i < triangles.size() / 3; ++i) {
+        details::dda_triangle(pixel_writer, { triangles[i * 3 + 0], triangles[i * 3 + 1], triangles[i * 3 + 2] }, i, distance);
+    }
+}
+
+template <typename PixelWriterFunction> void rasterize_line(const PixelWriterFunction& pixel_writer, const std::vector<glm::vec2>& line_points, float distance = 0.0)
+{
+    for (size_t i = 0; i < line_points.size() - 1; ++i) {
+        details::dda_line(pixel_writer, { line_points[i + 0], line_points[i + 1] }, i, distance);
+    }
+}
 
 } // namespace nucleus::utils::rasterizer

--- a/nucleus/utils/rasterizer.h
+++ b/nucleus/utils/rasterizer.h
@@ -16,11 +16,21 @@
  * along with this program.  If not, see <http://www.gnu.org/licenses/>.
  *****************************************************************************/
 
+#include <array>
+#include <iostream>
 #include <vector>
 
 #include <glm/glm.hpp>
 
 namespace nucleus::utils::rasterizer {
+
+// Possible future improvements:
+// - DDA -> prevent fill_inner_triangle to be called twice for the same row (if we switch from one line to another)
+//      - also check overall how often each pixel is written to
+
+// TODOs:
+// - enlarge triangles
+// - line renderer
 
 namespace details {
 
@@ -33,51 +43,69 @@ namespace details {
 
     inline std::pair<glm::vec2, int> calculate_dda_steps(const glm::vec2 line)
     {
-        int steps = fabs(line.x) > fabs(line.y) ? fabs(line.x) : fabs(line.y);
+        int steps = ceil(fabs(line.x) > fabs(line.y) ? fabs(line.x) : fabs(line.y));
+        // should only be triggered if two vertices of a triangle are exactly on the same position
+        // -> the input data is wrong
+        assert(steps > 0);
+        // steps = std::max(steps, 1); // alternative force at least one dda step -> wrong output but it should at least "work"
 
         auto step_size = glm::vec2(line.x / float(steps), line.y / float(steps));
+
+        // double the steps -> otherwise we might miss important pixels
+        steps *= 2;
+        step_size /= 2.0f;
 
         return std::make_pair(step_size, steps);
     }
 
     template <typename PixelWriterFunction>
-    void dda_triangle_line(
-        const PixelWriterFunction& pixel_writer, const glm::vec2 origin0, const glm::vec2 line0, const glm::vec2 origin1, const glm::vec2 line1, unsigned int data_index, int fill_direction)
+    inline void fill_inner_triangle(
+        const PixelWriterFunction& pixel_writer, const glm::vec2& current_position, const glm::vec2& top_point, const glm::vec2& top_bottom_line, unsigned int data_index, int fill_direction)
     {
+        // calculate the x value of the top_bottom edge
+        int x = get_x_for_y_on_line(top_point, top_bottom_line, current_position.y) + fill_direction;
 
+        for (int j = current_position.x; j != x; j += fill_direction) {
+            pixel_writer(glm::vec2(j, current_position.y), data_index);
+        }
+    }
+
+    template <typename PixelWriterFunction>
+    void dda_triangle_line(const PixelWriterFunction& pixel_writer,
+        const glm::vec2& line_start_point,
+        const glm::vec2& line,
+        const glm::vec2& top_point,
+        const glm::vec2& top_bottom_line,
+        unsigned int data_index,
+        int fill_direction)
+    {
         glm::vec2 step_size;
         int steps;
-        std::tie(step_size, steps) = calculate_dda_steps(line0);
+        std::tie(step_size, steps) = calculate_dda_steps(line);
 
-        // make sure that at least one step is applied
-        steps = std::max(steps, 1);
+        int last_y = 0;
 
-        glm::vec2 current_start_position = origin0;
-
-        glm::vec2 current_position = current_start_position;
+        glm::vec2 current_position = line_start_point;
 
         for (int j = 0; j < steps; j++) {
             pixel_writer(current_position, data_index);
 
-            // add a write step to x/y -> this prevents holes from thickness steps to appear by making the lines thicker
-            if (step_size.x < 1)
-                pixel_writer(current_position + glm::vec2(1, 0) * glm::sign(step_size.x), data_index);
-            if (step_size.y < 1)
-                pixel_writer(current_position + glm::vec2(0, 1) * glm::sign(step_size.y), data_index);
-
             if (int(current_position.y + step_size.y) > current_position.y) { // next step would go to next y value
 
-                int x = get_x_for_y_on_line(origin1, line1, current_position.y);
-
-                for (int j = current_position.x; j != x; j += fill_direction) {
-                    pixel_writer(glm::vec2(j, current_position.y), data_index);
-                }
+                fill_inner_triangle(pixel_writer, current_position, top_point, top_bottom_line, data_index, fill_direction);
+                last_y = current_position.y;
             }
             current_position += step_size;
         }
+
+        current_position -= step_size;
+
+        // check if we have to apply the fill_inner_triangle alg for the current row
+        if (last_y != floor(current_position.y))
+            fill_inner_triangle(pixel_writer, current_position, top_point, top_bottom_line, data_index, fill_direction);
     }
 
-    template <typename PixelWriterFunction> void dda_triangle(const PixelWriterFunction& pixel_writer, std::vector<glm::vec2> triangle, unsigned int triangle_index)
+    template <typename PixelWriterFunction> void dda_triangle(const PixelWriterFunction& pixel_writer, const std::vector<glm::vec2>& triangle, unsigned int triangle_index)
     {
         auto edge_top_bottom = triangle[2] - triangle[0];
         auto edge_top_middle = triangle[1] - triangle[0];
@@ -113,15 +141,31 @@ namespace details {
         // // middle bottom line
         dda_triangle_line(pixel_writer, triangle[1], edge_middle_bottom, triangle[0], edge_top_bottom, triangle_index, fill_direction);
 
-        // DEBUG draw lines with certain index
-        // dda_line(triangle[0], edge_top_bottom, normal_top_bottom * 1.0f, 100, 0, true);
-        // dda_line(triangle[0], edge_top_middle, normal_top_middle * 1.0f, 100, fill_direction, true);
-        // dda_line(triangle[1], edge_middle_bottom, normal_middle_bottom * 1.0f, 100, fill_direction, true);
-
         // TODO enable again
         // add_end_cap(triangle_collection.cell_to_data, triangle[0], triangle_index, thickness);
         // add_end_cap(triangle_collection.cell_to_data, triangle[1], triangle_index, thickness);
         // add_end_cap(triangle_collection.cell_to_data, triangle[2], triangle_index, thickness);
+    }
+
+    template <typename PixelWriterFunction>
+    void triangle_sdf(const PixelWriterFunction& pixel_writer, const glm::vec2 current_position, const std::array<glm::vec2, 3> points, unsigned int data_index, float distance)
+    {
+        // https://iquilezles.org/articles/distfunctions2d/
+
+        glm::vec2 e0 = points[1] - points[0], e1 = points[2] - points[1], e2 = points[0] - points[2];
+        float s = glm::sign(e0.x * e2.y - e0.y * e2.x);
+
+        glm::vec2 v0 = current_position - points[0], v1 = current_position - points[1], v2 = current_position - points[2];
+        glm::vec2 pq0 = v0 - e0 * glm::clamp(glm::dot(v0, e0) / glm::dot(e0, e0), 0.0f, 1.0f);
+        glm::vec2 pq1 = v1 - e1 * glm::clamp(glm::dot(v1, e1) / glm::dot(e1, e1), 0.0f, 1.0f);
+        glm::vec2 pq2 = v2 - e2 * glm::clamp(glm::dot(v2, e2) / glm::dot(e2, e2), 0.0f, 1.0f);
+        glm::vec2 d
+            = min(min(glm::vec2(dot(pq0, pq0), s * (v0.x * e0.y - v0.y * e0.x)), glm::vec2(dot(pq1, pq1), s * (v1.x * e1.y - v1.y * e1.x))), glm::vec2(dot(pq2, pq2), s * (v2.x * e2.y - v2.y * e2.x)));
+        float dist_from_tri = -sqrt(d.x) * glm::sign(d.y);
+
+        if (dist_from_tri < distance) {
+            pixel_writer(current_position, data_index);
+        }
     }
 
 } // namespace details
@@ -130,7 +174,29 @@ namespace details {
 // output: top, middle, bottom, top, middle,...
 std::vector<glm::vec2> triangulize(std::vector<glm::vec2> polygons);
 
-template <typename PixelWriterFunction> void rasterize_triangle(const PixelWriterFunction& pixel_writer, std::vector<glm::vec2> triangles)
+// ideal if you want to rasterize only a few triangles, where every triangle covers a large part of the raster size
+// in this method every pixel traverses every triangle
+template <typename PixelWriterFunction> void rasterize_triangle_sdf(const PixelWriterFunction& pixel_writer, const std::vector<glm::vec2>& triangles, float distance, const glm::ivec2 grid_size)
+{
+    // we sample from the center
+    // and have a radius of a half pixel diagonal
+    // this still leads to false positives if the edge of a triangle is slighly in another pixel without every comming in this pixel
+    distance += sqrt(0.5);
+
+    for (uint8_t i = 0; i < grid_size.x; i++) {
+        for (uint8_t j = 0; j < grid_size.y; j++) {
+            auto current_position = glm::vec2 { i + 0.5, j + 0.5 };
+
+            for (size_t i = 0; i < triangles.size() / 3; ++i) {
+                details::triangle_sdf(pixel_writer, current_position, { triangles[i * 3 + 0], triangles[i * 3 + 1], triangles[i * 3 + 2] }, i, distance);
+            }
+        }
+    }
+}
+
+// ideal for many triangles. especially if each triangle only covers small parts of the raster
+// in this method every triangle is traversed only once, and it only accesses pixels it needs for itself.
+template <typename PixelWriterFunction> void rasterize_triangle(const PixelWriterFunction& pixel_writer, const std::vector<glm::vec2>& triangles)
 {
     for (size_t i = 0; i < triangles.size() / 3; ++i) {
         details::dda_triangle(pixel_writer, { triangles[i * 3 + 0], triangles[i * 3 + 1], triangles[i * 3 + 2] }, i);

--- a/nucleus/utils/rasterizer.h
+++ b/nucleus/utils/rasterizer.h
@@ -505,7 +505,7 @@ namespace details {
  * triangulizes polygons and orders the vertices by y position per triangle
  * output: top, middle, bottom, top, middle,...
  */
-// std::vector<glm::vec2> triangulize(std::vector<glm::vec2> polygons);
+std::vector<glm::vec2> triangulize(std::vector<glm::vec2> polygons);
 
 /*
  * ideal if you want to rasterize only a few triangles, where every triangle covers a large part of the raster size

--- a/nucleus/utils/rasterizer.h
+++ b/nucleus/utils/rasterizer.h
@@ -1,0 +1,143 @@
+/*****************************************************************************
+ * AlpineMaps.org
+ * Copyright (C) 2024 Lucas Dworschak
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with this program.  If not, see <http://www.gnu.org/licenses/>.
+ *****************************************************************************/
+
+#include <vector>
+
+#include <glm/glm.hpp>
+
+namespace nucleus::utils::rasterizer {
+
+namespace details {
+
+    inline float get_x_for_y_on_line(const glm::vec2 origin, const glm::vec2 line, float y)
+    {
+        // pos_on_line = origin + t * line
+        float t = (y - origin.y) / line.y;
+        return origin.x + t * line.x;
+    }
+
+    inline std::pair<glm::vec2, int> calculate_dda_steps(const glm::vec2 line)
+    {
+        int steps = fabs(line.x) > fabs(line.y) ? fabs(line.x) : fabs(line.y);
+
+        auto step_size = glm::vec2(line.x / float(steps), line.y / float(steps));
+
+        return std::make_pair(step_size, steps);
+    }
+
+    template <typename PixelWriterFunction>
+    void dda_triangle_line(
+        const PixelWriterFunction& pixel_writer, const glm::vec2 origin0, const glm::vec2 line0, const glm::vec2 origin1, const glm::vec2 line1, unsigned int data_index, int fill_direction)
+    {
+
+        glm::vec2 step_size;
+        int steps;
+        std::tie(step_size, steps) = calculate_dda_steps(line0);
+
+        // make sure that at least one step is applied
+        steps = std::max(steps, 1);
+
+        glm::vec2 current_start_position = origin0;
+
+        glm::vec2 current_position = current_start_position;
+
+        for (int j = 0; j < steps; j++) {
+            pixel_writer(current_position, data_index);
+
+            // add a write step to x/y -> this prevents holes from thickness steps to appear by making the lines thicker
+            if (step_size.x < 1)
+                pixel_writer(current_position + glm::vec2(1, 0) * glm::sign(step_size.x), data_index);
+            if (step_size.y < 1)
+                pixel_writer(current_position + glm::vec2(0, 1) * glm::sign(step_size.y), data_index);
+
+            if (int(current_position.y + step_size.y) > current_position.y) { // next step would go to next y value
+
+                int x = get_x_for_y_on_line(origin1, line1, current_position.y);
+
+                for (int j = current_position.x; j != x; j += fill_direction) {
+                    pixel_writer(glm::vec2(j, current_position.y), data_index);
+                }
+            }
+            current_position += step_size;
+        }
+    }
+
+    template <typename PixelWriterFunction> void dda_triangle(const PixelWriterFunction& pixel_writer, std::vector<glm::vec2> triangle, unsigned int triangle_index)
+    {
+        auto edge_top_bottom = triangle[2] - triangle[0];
+        auto edge_top_middle = triangle[1] - triangle[0];
+        auto edge_middle_bottom = triangle[2] - triangle[1];
+
+        // TODO apply make triangle bigger lambda function if it was passed
+
+        // auto normal_top_bottom = glm::normalize(glm::vec2(-edge_top_bottom.y, edge_top_bottom.x));
+        // auto normal_top_middle = glm::normalize(glm::vec2(-edge_top_middle.y, edge_top_middle.x));
+        // auto normal_middle_bottom = glm::normalize(glm::vec2(-edge_middle_bottom.y, edge_middle_bottom.x));
+
+        // { // swap normal direction if they are incorrect (pointing to center)
+        //     glm::vec2 centroid = (triangle[0] + triangle[1] + triangle[2]) / 3.0f;
+        //     if (glm::dot(normal_top_bottom, centroid - triangle[0]) > 0) {
+        //         normal_top_bottom *= -1;
+        //     }
+        //     if (glm::dot(normal_top_middle, centroid - triangle[0]) > 0) {
+        //         normal_top_middle *= -1;
+        //     }
+        //     if (glm::dot(normal_middle_bottom, centroid - triangle[1]) > 0) {
+        //         normal_middle_bottom *= -1;
+        //     }
+        // }
+
+        // top bottom line
+        // dda_line(pixel_writer, , triangle_index, 0, true);
+
+        // do we have to fill the triangle from right to left(-1) or from left to right(1)
+        int fill_direction = (triangle[1].x < triangle[2].x) ? 1 : -1;
+
+        // // top middle line
+        dda_triangle_line(pixel_writer, triangle[0], edge_top_middle, triangle[0], edge_top_bottom, triangle_index, fill_direction);
+        // // middle bottom line
+        dda_triangle_line(pixel_writer, triangle[1], edge_middle_bottom, triangle[0], edge_top_bottom, triangle_index, fill_direction);
+
+        // DEBUG draw lines with certain index
+        // dda_line(triangle[0], edge_top_bottom, normal_top_bottom * 1.0f, 100, 0, true);
+        // dda_line(triangle[0], edge_top_middle, normal_top_middle * 1.0f, 100, fill_direction, true);
+        // dda_line(triangle[1], edge_middle_bottom, normal_middle_bottom * 1.0f, 100, fill_direction, true);
+
+        // TODO enable again
+        // add_end_cap(triangle_collection.cell_to_data, triangle[0], triangle_index, thickness);
+        // add_end_cap(triangle_collection.cell_to_data, triangle[1], triangle_index, thickness);
+        // add_end_cap(triangle_collection.cell_to_data, triangle[2], triangle_index, thickness);
+    }
+
+} // namespace details
+
+// triangulizes polygons and orders the vertices by y position per triangle
+// output: top, middle, bottom, top, middle,...
+std::vector<glm::vec2> triangulize(std::vector<glm::vec2> polygons);
+
+template <typename PixelWriterFunction> void rasterize_triangle(const PixelWriterFunction& pixel_writer, std::vector<glm::vec2> triangles)
+{
+    for (size_t i = 0; i < triangles.size() / 3; ++i) {
+        details::dda_triangle(pixel_writer, { triangles[i * 3 + 0], triangles[i * 3 + 1], triangles[i * 3 + 2] }, i);
+    }
+}
+
+// template <typename PixelWriterFunction>
+// void rasterize_line(const PixelWriterFunction& pixel_writer, std::vector<glm::vec2> line_points);
+
+} // namespace nucleus::utils::rasterizer

--- a/nucleus/utils/rasterizer.h
+++ b/nucleus/utils/rasterizer.h
@@ -505,7 +505,7 @@ namespace details {
  * triangulizes polygons and orders the vertices by y position per triangle
  * output: top, middle, bottom, top, middle,...
  */
-std::vector<glm::vec2> triangulize(std::vector<glm::vec2> polygons);
+// std::vector<glm::vec2> triangulize(std::vector<glm::vec2> polygons);
 
 /*
  * ideal if you want to rasterize only a few triangles, where every triangle covers a large part of the raster size

--- a/unittests/nucleus/CMakeLists.txt
+++ b/unittests/nucleus/CMakeLists.txt
@@ -25,6 +25,7 @@ alp_add_unittest(unittests_nucleus
     DrawListGenerator.cpp
     test_helpers.h test_helpers.cpp
     raster.cpp
+    rasterizer.cpp
     terrain_mesh_index_generator.cpp
     srs.cpp
     track.cpp

--- a/unittests/nucleus/rasterizer.cpp
+++ b/unittests/nucleus/rasterizer.cpp
@@ -1,0 +1,169 @@
+/*****************************************************************************
+ * AlpineMaps.org
+ * Copyright (C) 2024 Lucas Dworschak
+ * Copyright (C) 2024 Adam Celarek
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with this program.  If not, see <http://www.gnu.org/licenses/>.
+ *****************************************************************************/
+
+#include <QSignalSpy>
+#include <catch2/catch_test_macros.hpp>
+
+#include <CDT.h>
+
+#include "nucleus/Raster.h"
+#include "nucleus/tile/conversion.h"
+#include "nucleus/utils/rasterizer.h"
+
+TEST_CASE("nucleus/rasterizer")
+{
+    SECTION("Triangulation")
+    {
+        // 5 point polygon
+        // basically a square where one side contains an inward facing triangle
+        // a triangulation algorithm should be able to discern that 3 triangles are needed to construct this shape
+        const std::vector<glm::vec2> points = { glm::vec2(0, 0), glm::vec2(1, 1), glm::vec2(0, 2), glm::vec2(2, 2), glm::vec2(2, 0) };
+        const std::vector<glm::ivec2> edges = { glm::ivec2(0, 1), glm::ivec2(1, 2), glm::ivec2(2, 3), glm::ivec2(3, 4), glm::ivec2(4, 0) };
+
+        CDT::Triangulation<double> cdt;
+        cdt.insertVertices(points.begin(), points.end(), [](const glm::vec2& p) { return p.x; }, [](const glm::vec2& p) { return p.y; });
+        cdt.insertEdges(edges.begin(), edges.end(), [](const glm::ivec2& p) { return p.x; }, [](const glm::ivec2& p) { return p.y; });
+        cdt.eraseOuterTrianglesAndHoles();
+
+        auto tri = cdt.triangles;
+        auto vert = cdt.vertices;
+
+        // check if only 3 triangles have been found
+        CHECK(tri.size() == 3);
+
+        // 1st triangle
+        CHECK(vert[tri[0].vertices[0]].x == 0.0);
+        CHECK(vert[tri[0].vertices[0]].y == 2.0);
+        CHECK(vert[tri[0].vertices[1]].x == 1.0);
+        CHECK(vert[tri[0].vertices[1]].y == 1.0);
+        CHECK(vert[tri[0].vertices[2]].x == 2.0);
+        CHECK(vert[tri[0].vertices[2]].y == 2.0);
+
+        // 2nd triangle
+        CHECK(vert[tri[1].vertices[0]].x == 1.0);
+        CHECK(vert[tri[1].vertices[0]].y == 1.0);
+        CHECK(vert[tri[1].vertices[1]].x == 2.0);
+        CHECK(vert[tri[1].vertices[1]].y == 0.0);
+        CHECK(vert[tri[1].vertices[2]].x == 2.0);
+        CHECK(vert[tri[1].vertices[2]].y == 2.0);
+
+        // 3rd triangle
+        CHECK(vert[tri[2].vertices[0]].x == 1.0);
+        CHECK(vert[tri[2].vertices[0]].y == 1.0);
+        CHECK(vert[tri[2].vertices[1]].x == 0.0);
+        CHECK(vert[tri[2].vertices[1]].y == 0.0);
+        CHECK(vert[tri[2].vertices[2]].x == 2.0);
+        CHECK(vert[tri[2].vertices[2]].y == 0.0);
+
+        // DEBUG print out all the points of the triangles (to check what might have went wrong)
+        // for (std::size_t i = 0; i < tri.size(); i++) {
+        //     printf("Triangle points: [[%f, %f], [%f, %f], [%f, %f]]\n",
+        //         vert[tri[i].vertices[0]].x, // x0
+        //         vert[tri[i].vertices[0]].y, // y0
+        //         vert[tri[i].vertices[1]].x, // x1
+        //         vert[tri[i].vertices[1]].y, // y1
+        //         vert[tri[i].vertices[2]].x, // x2
+        //         vert[tri[i].vertices[2]].y // y2
+        //     );
+        // }
+    }
+
+    SECTION("Triangle y ordering")
+    {
+        // make sure that the triangle_order function correctly orders the triangle points from lowest y to highest y value
+        const std::vector<glm::vec2> triangle_points_012 = { { glm::vec2(30, 10), glm::vec2(10, 30), glm::vec2(50, 50) } };
+        const std::vector<glm::vec2> triangle_points_021 = { glm::vec2(30, 10), glm::vec2(50, 50), glm::vec2(10, 30) };
+        const std::vector<glm::vec2> triangle_points_102 = { glm::vec2(10, 30), glm::vec2(30, 10), glm::vec2(50, 50) };
+        const std::vector<glm::vec2> triangle_points_201 = { glm::vec2(10, 30), glm::vec2(50, 50), glm::vec2(30, 10) };
+        const std::vector<glm::vec2> triangle_points_120 = { glm::vec2(50, 50), glm::vec2(30, 10), glm::vec2(10, 30) };
+        const std::vector<glm::vec2> triangle_points_210 = { glm::vec2(50, 50), glm::vec2(10, 30), glm::vec2(30, 10) };
+
+        const std::vector<glm::vec2> correct = { { glm::vec2(30, 10), glm::vec2(10, 30), glm::vec2(50, 50) } };
+
+        CHECK(correct == nucleus::utils::rasterizer::triangulize(triangle_points_012));
+        CHECK(correct == nucleus::utils::rasterizer::triangulize(triangle_points_021));
+        CHECK(correct == nucleus::utils::rasterizer::triangulize(triangle_points_102));
+        CHECK(correct == nucleus::utils::rasterizer::triangulize(triangle_points_201));
+        CHECK(correct == nucleus::utils::rasterizer::triangulize(triangle_points_120));
+        CHECK(correct == nucleus::utils::rasterizer::triangulize(triangle_points_210));
+    }
+
+    SECTION("rasterize triangle")
+    {
+        // two triangles
+        const std::vector<glm::vec2> triangles = { glm::vec2(30.5, 10.5), glm::vec2(10.5, 30.5), glm::vec2(50.5, 50.5), glm::vec2(5.5, 5.5), glm::vec2(15.5, 10.5), glm::vec2(5.5, 15.5) };
+
+        nucleus::Raster<uint8_t> output({ 64, 64 }, 0u);
+        const auto pixel_writer = [&output](glm::vec2 pos, int) { output.pixel(pos) = 255; };
+        nucleus::utils::rasterizer::rasterize_triangle(pixel_writer, triangles);
+
+        nucleus::Raster<uint8_t> output2({ 64, 64 }, 0u);
+        const auto pixel_writer2 = [&output2](glm::vec2 pos, int) { output2.pixel(pos) = 255; };
+        nucleus::utils::rasterizer::rasterize_triangle_sdf(pixel_writer2, triangles, 0, output2.size());
+
+        CHECK(output.buffer() == output2.buffer());
+
+        // DEBUG: save image (image saved to build/Desktop-Profile/unittests/nucleus)
+        // auto image = nucleus::tile::conversion::u8raster_to_qimage(output);
+        // image.save(QString("rasterizer_output.png"));
+        // auto image2 = nucleus::tile::conversion::u8raster_to_qimage(output2);
+        // image2.save(QString("rasterizer_output_sdf.png"));
+    }
+
+    SECTION("rasterize triangle small")
+    {
+        const std::vector<glm::vec2> triangles_small = { glm::vec2(2, 2), glm::vec2(1, 3), glm::vec2(3.8, 3.8) };
+        nucleus::Raster<uint8_t> output({ 6, 6 }, 0u);
+        const auto pixel_writer = [&output](glm::vec2 pos, int) { output.pixel(pos) = 255; };
+        nucleus::utils::rasterizer::rasterize_triangle(pixel_writer, triangles_small);
+
+        nucleus::Raster<uint8_t> output2({ 6, 6 }, 0u);
+        const auto pixel_writer2 = [&output2](glm::vec2 pos, int) { output2.pixel(pos) = 255; };
+        nucleus::utils::rasterizer::rasterize_triangle_sdf(pixel_writer2, triangles_small, 0, output2.size());
+
+        CHECK(output.buffer() == output2.buffer());
+
+        // DEBUG: save image (image saved to build/Desktop-Profile/unittests/nucleus)
+        // auto image = nucleus::tile::conversion::u8raster_to_qimage(output);
+        // image.save(QString("rasterizer_output_small.png"));
+        // auto image2 = nucleus::tile::conversion::u8raster_to_qimage(output2);
+        // image2.save(QString("rasterizer_output_small_sdf.png"));
+    }
+
+    SECTION("rasterize triangle smallest")
+    {
+        // less than one pixel
+        const std::vector<glm::vec2> triangles_smallest = { glm::vec2(30.4, 30.4), glm::vec2(30.8, 30.6), glm::vec2(30.8, 30.8) };
+        nucleus::Raster<uint8_t> output({ 64, 64 }, 0u);
+        const auto pixel_writer = [&output](glm::vec2 pos, int) { output.pixel(pos) = 255; };
+        nucleus::utils::rasterizer::rasterize_triangle(pixel_writer, triangles_smallest);
+
+        nucleus::Raster<uint8_t> output2({ 64, 64 }, 0u);
+        const auto pixel_writer2 = [&output2](glm::vec2 pos, int) { output2.pixel(pos) = 255; };
+        nucleus::utils::rasterizer::rasterize_triangle_sdf(pixel_writer2, triangles_smallest, 0, output2.size());
+
+        CHECK(output.buffer() == output2.buffer());
+
+        // DEBUG: save image (image saved to build/Desktop-Profile/unittests/nucleus)
+        // auto image = nucleus::tile::conversion::u8raster_to_qimage(output);
+        // image.save(QString("rasterizer_output_smallest.png"));
+        // auto image2 = nucleus::tile::conversion::u8raster_to_qimage(output2);
+        // image2.save(QString("rasterizer_output_smallest_sdf.png"));
+    }
+}

--- a/unittests/nucleus/rasterizer.cpp
+++ b/unittests/nucleus/rasterizer.cpp
@@ -20,7 +20,7 @@
 #include <QSignalSpy>
 #include <catch2/catch_test_macros.hpp>
 
-// #include <CDT.h>
+#include <CDT.h>
 
 #include "nucleus/Raster.h"
 // #include "nucleus/tile/conversion.h"
@@ -36,61 +36,61 @@ TEST_CASE("nucleus/rasterizer")
     // but future changes might cause problems, when there shouldn't be problems
     // so if a test fails check the debug images to see what exactly went wrong.
 
-    // SECTION("Triangulation")
-    // {
-    //     // 5 point polygon
-    //     // basically a square where one side contains an inward facing triangle
-    //     // a triangulation algorithm should be able to discern that 3 triangles are needed to construct this shape
-    //     const std::vector<glm::vec2> points = { glm::vec2(0, 0), glm::vec2(1, 1), glm::vec2(0, 2), glm::vec2(2, 2), glm::vec2(2, 0) };
-    //     const std::vector<glm::ivec2> edges = { glm::ivec2(0, 1), glm::ivec2(1, 2), glm::ivec2(2, 3), glm::ivec2(3, 4), glm::ivec2(4, 0) };
+    SECTION("Triangulation")
+    {
+        // 5 point polygon
+        // basically a square where one side contains an inward facing triangle
+        // a triangulation algorithm should be able to discern that 3 triangles are needed to construct this shape
+        const std::vector<glm::vec2> points = { glm::vec2(0, 0), glm::vec2(1, 1), glm::vec2(0, 2), glm::vec2(2, 2), glm::vec2(2, 0) };
+        const std::vector<glm::ivec2> edges = { glm::ivec2(0, 1), glm::ivec2(1, 2), glm::ivec2(2, 3), glm::ivec2(3, 4), glm::ivec2(4, 0) };
 
-    //     CDT::Triangulation<double> cdt;
-    //     cdt.insertVertices(points.begin(), points.end(), [](const glm::vec2& p) { return p.x; }, [](const glm::vec2& p) { return p.y; });
-    //     cdt.insertEdges(edges.begin(), edges.end(), [](const glm::ivec2& p) { return p.x; }, [](const glm::ivec2& p) { return p.y; });
-    //     cdt.eraseOuterTrianglesAndHoles();
+        CDT::Triangulation<double> cdt;
+        cdt.insertVertices(points.begin(), points.end(), [](const glm::vec2& p) { return p.x; }, [](const glm::vec2& p) { return p.y; });
+        cdt.insertEdges(edges.begin(), edges.end(), [](const glm::ivec2& p) { return p.x; }, [](const glm::ivec2& p) { return p.y; });
+        cdt.eraseOuterTrianglesAndHoles();
 
-    //     auto tri = cdt.triangles;
-    //     auto vert = cdt.vertices;
+        auto tri = cdt.triangles;
+        auto vert = cdt.vertices;
 
-    //     // check if only 3 triangles have been found
-    //     CHECK(tri.size() == 3);
+        // check if only 3 triangles have been found
+        CHECK(tri.size() == 3);
 
-    //     // 1st triangle
-    //     CHECK(vert[tri[0].vertices[0]].x == 0.0);
-    //     CHECK(vert[tri[0].vertices[0]].y == 2.0);
-    //     CHECK(vert[tri[0].vertices[1]].x == 1.0);
-    //     CHECK(vert[tri[0].vertices[1]].y == 1.0);
-    //     CHECK(vert[tri[0].vertices[2]].x == 2.0);
-    //     CHECK(vert[tri[0].vertices[2]].y == 2.0);
+        // 1st triangle
+        CHECK(vert[tri[0].vertices[0]].x == 0.0);
+        CHECK(vert[tri[0].vertices[0]].y == 2.0);
+        CHECK(vert[tri[0].vertices[1]].x == 1.0);
+        CHECK(vert[tri[0].vertices[1]].y == 1.0);
+        CHECK(vert[tri[0].vertices[2]].x == 2.0);
+        CHECK(vert[tri[0].vertices[2]].y == 2.0);
 
-    //     // 2nd triangle
-    //     CHECK(vert[tri[1].vertices[0]].x == 1.0);
-    //     CHECK(vert[tri[1].vertices[0]].y == 1.0);
-    //     CHECK(vert[tri[1].vertices[1]].x == 2.0);
-    //     CHECK(vert[tri[1].vertices[1]].y == 0.0);
-    //     CHECK(vert[tri[1].vertices[2]].x == 2.0);
-    //     CHECK(vert[tri[1].vertices[2]].y == 2.0);
+        // 2nd triangle
+        CHECK(vert[tri[1].vertices[0]].x == 1.0);
+        CHECK(vert[tri[1].vertices[0]].y == 1.0);
+        CHECK(vert[tri[1].vertices[1]].x == 2.0);
+        CHECK(vert[tri[1].vertices[1]].y == 0.0);
+        CHECK(vert[tri[1].vertices[2]].x == 2.0);
+        CHECK(vert[tri[1].vertices[2]].y == 2.0);
 
-    //     // 3rd triangle
-    //     CHECK(vert[tri[2].vertices[0]].x == 1.0);
-    //     CHECK(vert[tri[2].vertices[0]].y == 1.0);
-    //     CHECK(vert[tri[2].vertices[1]].x == 0.0);
-    //     CHECK(vert[tri[2].vertices[1]].y == 0.0);
-    //     CHECK(vert[tri[2].vertices[2]].x == 2.0);
-    //     CHECK(vert[tri[2].vertices[2]].y == 0.0);
+        // 3rd triangle
+        CHECK(vert[tri[2].vertices[0]].x == 1.0);
+        CHECK(vert[tri[2].vertices[0]].y == 1.0);
+        CHECK(vert[tri[2].vertices[1]].x == 0.0);
+        CHECK(vert[tri[2].vertices[1]].y == 0.0);
+        CHECK(vert[tri[2].vertices[2]].x == 2.0);
+        CHECK(vert[tri[2].vertices[2]].y == 0.0);
 
-    //     // DEBUG print out all the points of the triangles (to check what might have went wrong)
-    //     // for (std::size_t i = 0; i < tri.size(); i++) {
-    //     //     printf("Triangle points: [[%f, %f], [%f, %f], [%f, %f]]\n",
-    //     //         vert[tri[i].vertices[0]].x, // x0
-    //     //         vert[tri[i].vertices[0]].y, // y0
-    //     //         vert[tri[i].vertices[1]].x, // x1
-    //     //         vert[tri[i].vertices[1]].y, // y1
-    //     //         vert[tri[i].vertices[2]].x, // x2
-    //     //         vert[tri[i].vertices[2]].y // y2
-    //     //     );
-    //     // }
-    // }
+        // DEBUG print out all the points of the triangles (to check what might have went wrong)
+        // for (std::size_t i = 0; i < tri.size(); i++) {
+        //     printf("Triangle points: [[%f, %f], [%f, %f], [%f, %f]]\n",
+        //         vert[tri[i].vertices[0]].x, // x0
+        //         vert[tri[i].vertices[0]].y, // y0
+        //         vert[tri[i].vertices[1]].x, // x1
+        //         vert[tri[i].vertices[1]].y, // y1
+        //         vert[tri[i].vertices[2]].x, // x2
+        //         vert[tri[i].vertices[2]].y // y2
+        //     );
+        // }
+    }
 
     // SECTION("Triangle y ordering")
     // {

--- a/unittests/nucleus/rasterizer.cpp
+++ b/unittests/nucleus/rasterizer.cpp
@@ -650,33 +650,35 @@ TEST_CASE("nucleus/utils/rasterizer benchmarks")
     {
         const std::vector<glm::vec2> triangles = { glm::vec2(30.5, 10.5), glm::vec2(10.5, 30.5), glm::vec2(50.5, 50.5), glm::vec2(5.5, 5.5), glm::vec2(15.5, 10.5), glm::vec2(5.5, 15.5) };
 
-        nucleus::Raster<uint8_t> output({ 64, 64 }, 0u);
-        const auto pixel_writer = [&output](glm::ivec2 pos) { output.pixel(pos) = 255; };
+        // we dont particular care how long it takes to write to raster -> so do nothing
+        const auto pixel_writer = [](glm::ivec2) { /*do nothing*/ };
         nucleus::utils::rasterizer::rasterize_triangle(pixel_writer, triangles);
     };
 
-    BENCHMARK("Rasterize triangle (no raster write)")
+    BENCHMARK("Rasterize triangle distance")
     {
         const std::vector<glm::vec2> triangles = { glm::vec2(30.5, 10.5), glm::vec2(10.5, 30.5), glm::vec2(50.5, 50.5), glm::vec2(5.5, 5.5), glm::vec2(15.5, 10.5), glm::vec2(5.5, 15.5) };
 
+        // we dont particular care how long it takes to write to raster -> so do nothing
         const auto pixel_writer = [](glm::ivec2) { /*do nothing*/ };
-        nucleus::utils::rasterizer::rasterize_triangle(pixel_writer, triangles);
+        nucleus::utils::rasterizer::rasterize_triangle(pixel_writer, triangles, 5.0);
     };
 
     BENCHMARK("Rasterize triangle SDF")
     {
         const std::vector<glm::vec2> triangles = { glm::vec2(30.5, 10.5), glm::vec2(10.5, 30.5), glm::vec2(50.5, 50.5), glm::vec2(5.5, 5.5), glm::vec2(15.5, 10.5), glm::vec2(5.5, 15.5) };
 
-        nucleus::Raster<uint8_t> output2({ 64, 64 }, 0u);
-        auto pixel_writer = [&output2](glm::ivec2 pos) { output2.pixel(pos) = 255; };
+        // we dont particular care how long it takes to write to raster -> so do nothing
+        const auto pixel_writer = [](glm::ivec2) { /*do nothing*/ };
         rasterize_triangle_sdf(pixel_writer, triangles, 0);
     };
 
-    BENCHMARK("Rasterize triangle SDF (no raster write)")
+    BENCHMARK("Rasterize triangle SDF distance")
     {
         const std::vector<glm::vec2> triangles = { glm::vec2(30.5, 10.5), glm::vec2(10.5, 30.5), glm::vec2(50.5, 50.5), glm::vec2(5.5, 5.5), glm::vec2(15.5, 10.5), glm::vec2(5.5, 15.5) };
 
+        // we dont particular care how long it takes to write to raster -> so do nothing
         const auto pixel_writer = [](glm::ivec2) { /*do nothing*/ };
-        rasterize_triangle_sdf(pixel_writer, triangles, 0);
+        rasterize_triangle_sdf(pixel_writer, triangles, 5.0);
     };
 }

--- a/unittests/nucleus/rasterizer.cpp
+++ b/unittests/nucleus/rasterizer.cpp
@@ -122,8 +122,8 @@ TEST_CASE("nucleus/rasterizer")
         CHECK(output.buffer() == output2.buffer());
 
         // DEBUG: save image (image saved to build/Desktop-Profile/unittests/nucleus)
-        auto image = nucleus::tile::conversion::u8raster_2_to_qimage(output, output2);
-        image.save(QString("rasterizer_output.png"));
+        // auto image = nucleus::tile::conversion::u8raster_2_to_qimage(output, output2);
+        // image.save(QString("rasterizer_output.png"));
     }
 
     SECTION("rasterize triangle small")
@@ -140,10 +140,8 @@ TEST_CASE("nucleus/rasterizer")
         CHECK(output.buffer() == output2.buffer());
 
         // DEBUG: save image (image saved to build/Desktop-Profile/unittests/nucleus)
-        // auto image = nucleus::tile::conversion::u8raster_to_qimage(output);
+        // auto image = nucleus::tile::conversion::u8raster_2_to_qimage(output, output2);
         // image.save(QString("rasterizer_output_small.png"));
-        // auto image2 = nucleus::tile::conversion::u8raster_to_qimage(output2);
-        // image2.save(QString("rasterizer_output_small_sdf.png"));
     }
 
     SECTION("rasterize triangle smallest")
@@ -161,10 +159,8 @@ TEST_CASE("nucleus/rasterizer")
         CHECK(output.buffer() == output2.buffer());
 
         // DEBUG: save image (image saved to build/Desktop-Profile/unittests/nucleus)
-        // auto image = nucleus::tile::conversion::u8raster_to_qimage(output);
+        // auto image = nucleus::tile::conversion::u8raster_2_to_qimage(output, output2);
         // image.save(QString("rasterizer_output_smallest.png"));
-        // auto image2 = nucleus::tile::conversion::u8raster_to_qimage(output2);
-        // image2.save(QString("rasterizer_output_smallest_sdf.png"));
     }
 
     SECTION("rasterize triangle enlarged endcaps only")
@@ -201,11 +197,21 @@ TEST_CASE("nucleus/rasterizer")
     SECTION("rasterize triangle enlarged")
     {
         // less than one pixel
-        const std::vector<glm::vec2> triangles = { glm::vec2(30.5, 10.5), glm::vec2(10.5, 30.5), glm::vec2(50.5, 50.5), glm::vec2(5.5, 5.5), glm::vec2(15.5, 10.5), glm::vec2(5.5, 15.5) };
+        const std::vector<glm::vec2> triangles = { glm::vec2(30.5, 10.5),
+            glm::vec2(10.5, 30.5),
+            glm::vec2(50.5, 50.5),
+
+            glm::vec2(5.5, 5.5),
+            glm::vec2(15.5, 10.5),
+            glm::vec2(5.5, 15.5),
+
+            glm::vec2(15.5, 50.5),
+            glm::vec2(5.5, 50.5),
+            glm::vec2(10.5, 60.5) };
         // const std::vector<glm::vec2> triangles = { glm::vec2(5.35, 5.35), glm::vec2(5.40, 5.40), glm::vec2(5.45, 5.35) };
         auto size = glm::vec2(64, 64);
         nucleus::Raster<uint8_t> output(size, 0u);
-        float distance = 4.0;
+        float distance = 5.0;
         radix::geometry::Aabb2<double> bounds = { { 0, 0 }, size };
 
         const auto pixel_writer = [&output, bounds](glm::vec2 pos, int) {
@@ -221,7 +227,7 @@ TEST_CASE("nucleus/rasterizer")
         };
         nucleus::utils::rasterizer::rasterize_triangle_sdf(pixel_writer2, triangles, distance, output2.size());
 
-        // CHECK(output.buffer() == output2.buffer());
+        CHECK(output.buffer() == output2.buffer());
 
         // DEBUG: save image (image saved to build/Desktop-Profile/unittests/nucleus)
         auto image = nucleus::tile::conversion::u8raster_2_to_qimage(output, output2);

--- a/unittests/nucleus/rasterizer.cpp
+++ b/unittests/nucleus/rasterizer.cpp
@@ -23,7 +23,7 @@
 #include <CDT.h>
 
 #include "nucleus/Raster.h"
-#include "nucleus/tile/conversion.h"
+// #include "nucleus/tile/conversion.h"
 #include "nucleus/utils/rasterizer.h"
 
 #include <radix/geometry.h>

--- a/unittests/nucleus/rasterizer.cpp
+++ b/unittests/nucleus/rasterizer.cpp
@@ -26,6 +26,8 @@
 #include "nucleus/tile/conversion.h"
 #include "nucleus/utils/rasterizer.h"
 
+#include <radix/geometry.h>
+
 TEST_CASE("nucleus/rasterizer")
 {
     SECTION("Triangulation")
@@ -104,66 +106,131 @@ TEST_CASE("nucleus/rasterizer")
         CHECK(correct == nucleus::utils::rasterizer::triangulize(triangle_points_210));
     }
 
-    SECTION("rasterize triangle")
-    {
-        // two triangles
-        const std::vector<glm::vec2> triangles = { glm::vec2(30.5, 10.5), glm::vec2(10.5, 30.5), glm::vec2(50.5, 50.5), glm::vec2(5.5, 5.5), glm::vec2(15.5, 10.5), glm::vec2(5.5, 15.5) };
+    // SECTION("rasterize triangle")
+    // {
+    //     // two triangles
+    //     const std::vector<glm::vec2> triangles = { glm::vec2(30.5, 10.5), glm::vec2(10.5, 30.5), glm::vec2(50.5, 50.5), glm::vec2(5.5, 5.5), glm::vec2(15.5, 10.5), glm::vec2(5.5, 15.5) };
 
-        nucleus::Raster<uint8_t> output({ 64, 64 }, 0u);
-        const auto pixel_writer = [&output](glm::vec2 pos, int) { output.pixel(pos) = 255; };
-        nucleus::utils::rasterizer::rasterize_triangle(pixel_writer, triangles);
+    //     nucleus::Raster<uint8_t> output({ 64, 64 }, 0u);
+    //     const auto pixel_writer = [&output](glm::vec2 pos, int) { output.pixel(pos) = 255; };
+    //     nucleus::utils::rasterizer::rasterize_triangle(pixel_writer, triangles);
 
-        nucleus::Raster<uint8_t> output2({ 64, 64 }, 0u);
-        const auto pixel_writer2 = [&output2](glm::vec2 pos, int) { output2.pixel(pos) = 255; };
-        nucleus::utils::rasterizer::rasterize_triangle_sdf(pixel_writer2, triangles, 0, output2.size());
+    //     nucleus::Raster<uint8_t> output2({ 64, 64 }, 0u);
+    //     const auto pixel_writer2 = [&output2](glm::vec2 pos, int) { output2.pixel(pos) = 255; };
+    //     nucleus::utils::rasterizer::rasterize_triangle_sdf(pixel_writer2, triangles, 0, output2.size());
 
-        CHECK(output.buffer() == output2.buffer());
+    //     CHECK(output.buffer() == output2.buffer());
 
-        // DEBUG: save image (image saved to build/Desktop-Profile/unittests/nucleus)
-        // auto image = nucleus::tile::conversion::u8raster_to_qimage(output);
-        // image.save(QString("rasterizer_output.png"));
-        // auto image2 = nucleus::tile::conversion::u8raster_to_qimage(output2);
-        // image2.save(QString("rasterizer_output_sdf.png"));
-    }
+    //     // DEBUG: save image (image saved to build/Desktop-Profile/unittests/nucleus)
+    //     // auto image = nucleus::tile::conversion::u8raster_to_qimage(output);
+    //     // image.save(QString("rasterizer_output.png"));
+    //     // auto image2 = nucleus::tile::conversion::u8raster_to_qimage(output2);
+    //     // image2.save(QString("rasterizer_output_sdf.png"));
+    // }
 
-    SECTION("rasterize triangle small")
-    {
-        const std::vector<glm::vec2> triangles_small = { glm::vec2(2, 2), glm::vec2(1, 3), glm::vec2(3.8, 3.8) };
-        nucleus::Raster<uint8_t> output({ 6, 6 }, 0u);
-        const auto pixel_writer = [&output](glm::vec2 pos, int) { output.pixel(pos) = 255; };
-        nucleus::utils::rasterizer::rasterize_triangle(pixel_writer, triangles_small);
+    // SECTION("rasterize triangle small")
+    // {
+    //     const std::vector<glm::vec2> triangles_small = { glm::vec2(2, 2), glm::vec2(1, 3), glm::vec2(3.8, 3.8) };
+    //     nucleus::Raster<uint8_t> output({ 6, 6 }, 0u);
+    //     const auto pixel_writer = [&output](glm::vec2 pos, int) { output.pixel(pos) = 255; };
+    //     nucleus::utils::rasterizer::rasterize_triangle(pixel_writer, triangles_small);
 
-        nucleus::Raster<uint8_t> output2({ 6, 6 }, 0u);
-        const auto pixel_writer2 = [&output2](glm::vec2 pos, int) { output2.pixel(pos) = 255; };
-        nucleus::utils::rasterizer::rasterize_triangle_sdf(pixel_writer2, triangles_small, 0, output2.size());
+    //     nucleus::Raster<uint8_t> output2({ 6, 6 }, 0u);
+    //     const auto pixel_writer2 = [&output2](glm::vec2 pos, int) { output2.pixel(pos) = 255; };
+    //     nucleus::utils::rasterizer::rasterize_triangle_sdf(pixel_writer2, triangles_small, 0, output2.size());
 
-        CHECK(output.buffer() == output2.buffer());
+    //     CHECK(output.buffer() == output2.buffer());
 
-        // DEBUG: save image (image saved to build/Desktop-Profile/unittests/nucleus)
-        // auto image = nucleus::tile::conversion::u8raster_to_qimage(output);
-        // image.save(QString("rasterizer_output_small.png"));
-        // auto image2 = nucleus::tile::conversion::u8raster_to_qimage(output2);
-        // image2.save(QString("rasterizer_output_small_sdf.png"));
-    }
+    //     // DEBUG: save image (image saved to build/Desktop-Profile/unittests/nucleus)
+    //     // auto image = nucleus::tile::conversion::u8raster_to_qimage(output);
+    //     // image.save(QString("rasterizer_output_small.png"));
+    //     // auto image2 = nucleus::tile::conversion::u8raster_to_qimage(output2);
+    //     // image2.save(QString("rasterizer_output_small_sdf.png"));
+    // }
 
-    SECTION("rasterize triangle smallest")
+    // SECTION("rasterize triangle smallest")
+    // {
+    //     // less than one pixel
+    //     const std::vector<glm::vec2> triangles_smallest = { glm::vec2(30.4, 30.4), glm::vec2(30.8, 30.6), glm::vec2(30.8, 30.8) };
+    //     nucleus::Raster<uint8_t> output({ 64, 64 }, 0u);
+    //     const auto pixel_writer = [&output](glm::vec2 pos, int) { output.pixel(pos) = 255; };
+    //     nucleus::utils::rasterizer::rasterize_triangle(pixel_writer, triangles_smallest);
+
+    //     nucleus::Raster<uint8_t> output2({ 64, 64 }, 0u);
+    //     const auto pixel_writer2 = [&output2](glm::vec2 pos, int) { output2.pixel(pos) = 255; };
+    //     nucleus::utils::rasterizer::rasterize_triangle_sdf(pixel_writer2, triangles_smallest, 0, output2.size());
+
+    //     CHECK(output.buffer() == output2.buffer());
+
+    //     // DEBUG: save image (image saved to build/Desktop-Profile/unittests/nucleus)
+    //     // auto image = nucleus::tile::conversion::u8raster_to_qimage(output);
+    //     // image.save(QString("rasterizer_output_smallest.png"));
+    //     // auto image2 = nucleus::tile::conversion::u8raster_to_qimage(output2);
+    //     // image2.save(QString("rasterizer_output_smallest_sdf.png"));
+    // }
+
+    SECTION("rasterize triangle enlarged endcaps only")
     {
         // less than one pixel
-        const std::vector<glm::vec2> triangles_smallest = { glm::vec2(30.4, 30.4), glm::vec2(30.8, 30.6), glm::vec2(30.8, 30.8) };
-        nucleus::Raster<uint8_t> output({ 64, 64 }, 0u);
-        const auto pixel_writer = [&output](glm::vec2 pos, int) { output.pixel(pos) = 255; };
-        nucleus::utils::rasterizer::rasterize_triangle(pixel_writer, triangles_smallest);
+        const std::vector<glm::vec2> triangles = { glm::vec2(5.35, 5.35), glm::vec2(5.40, 5.40), glm::vec2(5.45, 5.35) };
+        auto size = glm::vec2(10, 10);
+        nucleus::Raster<uint8_t> output(size, 0u);
+        float distance = 4.0;
+        radix::geometry::Aabb2<double> bounds = { { 0, 0 }, size };
 
-        nucleus::Raster<uint8_t> output2({ 64, 64 }, 0u);
-        const auto pixel_writer2 = [&output2](glm::vec2 pos, int) { output2.pixel(pos) = 255; };
-        nucleus::utils::rasterizer::rasterize_triangle_sdf(pixel_writer2, triangles_smallest, 0, output2.size());
+        const auto pixel_writer = [&output, bounds](glm::vec2 pos, int) {
+            if (bounds.contains(pos))
+                output.pixel(pos) = 255;
+        };
+        // nucleus::utils::rasterizer::rasterize_triangle(pixel_writer, triangles, distance);
+        nucleus::utils::rasterizer::details::add_end_cap(pixel_writer, triangles[0], 1, distance);
+        nucleus::utils::rasterizer::details::add_end_cap(pixel_writer, triangles[1], 1, distance);
+        nucleus::utils::rasterizer::details::add_end_cap(pixel_writer, triangles[2], 1, distance);
+
+        nucleus::Raster<uint8_t> output2(size, 0u);
+        const auto pixel_writer2 = [&output2, bounds](glm::vec2 pos, int) {
+            if (bounds.contains(pos))
+                output2.pixel(pos) = 255;
+        };
+        nucleus::utils::rasterizer::rasterize_triangle_sdf(pixel_writer2, triangles, distance, output2.size());
 
         CHECK(output.buffer() == output2.buffer());
 
         // DEBUG: save image (image saved to build/Desktop-Profile/unittests/nucleus)
-        // auto image = nucleus::tile::conversion::u8raster_to_qimage(output);
-        // image.save(QString("rasterizer_output_smallest.png"));
-        // auto image2 = nucleus::tile::conversion::u8raster_to_qimage(output2);
-        // image2.save(QString("rasterizer_output_smallest_sdf.png"));
+        // auto image = nucleus::tile::conversion::u8raster_2_to_qimage(output, output2);
+        // image.save(QString("rasterizer_output_enlarged_endcap.png"));
+    }
+
+    SECTION("rasterize triangle enlarged")
+    {
+        // less than one pixel
+        const std::vector<glm::vec2> triangles = { glm::vec2(30.5, 10.5), glm::vec2(10.5, 30.5), glm::vec2(50.5, 50.5), glm::vec2(5.5, 5.5), glm::vec2(15.5, 10.5), glm::vec2(5.5, 15.5) };
+        // const std::vector<glm::vec2> triangles = { glm::vec2(5.35, 5.35), glm::vec2(5.40, 5.40), glm::vec2(5.45, 5.35) };
+        auto size = glm::vec2(64, 64);
+        nucleus::Raster<uint8_t> output(size, 0u);
+        float distance = 4.0;
+        radix::geometry::Aabb2<double> bounds = { { 0, 0 }, size };
+
+        const auto pixel_writer = [&output, bounds](glm::vec2 pos, int) {
+            if (bounds.contains(pos))
+                output.pixel(pos) = 255;
+        };
+        nucleus::utils::rasterizer::rasterize_triangle(pixel_writer, triangles, distance);
+        // nucleus::utils::rasterizer::details::add_end_cap(pixel_writer, triangles[0], 1, distance);
+        // nucleus::utils::rasterizer::details::add_end_cap(pixel_writer, triangles[1], 1, distance);
+        // nucleus::utils::rasterizer::details::add_end_cap(pixel_writer, triangles[2], 1, distance);
+
+        nucleus::Raster<uint8_t> output2(size, 0u);
+        const auto pixel_writer2 = [&output2, bounds](glm::vec2 pos, int) {
+            if (bounds.contains(pos))
+                output2.pixel(pos) = 255;
+        };
+        nucleus::utils::rasterizer::rasterize_triangle_sdf(pixel_writer2, triangles, distance, output2.size());
+
+        // CHECK(output.buffer() == output2.buffer());
+
+        // DEBUG: save image (image saved to build/Desktop-Profile/unittests/nucleus)
+        auto image = nucleus::tile::conversion::u8raster_2_to_qimage(output, output2);
+        image.save(QString("rasterizer_output_enlarged.png"));
     }
 }

--- a/unittests/nucleus/rasterizer.cpp
+++ b/unittests/nucleus/rasterizer.cpp
@@ -92,25 +92,25 @@ TEST_CASE("nucleus/rasterizer")
         // }
     }
 
-    SECTION("Triangle y ordering")
-    {
-        // make sure that the triangle_order function correctly orders the triangle points from lowest y to highest y value
-        const std::vector<glm::vec2> triangle_points_012 = { { glm::vec2(30, 10), glm::vec2(10, 30), glm::vec2(50, 50) } };
-        const std::vector<glm::vec2> triangle_points_021 = { glm::vec2(30, 10), glm::vec2(50, 50), glm::vec2(10, 30) };
-        const std::vector<glm::vec2> triangle_points_102 = { glm::vec2(10, 30), glm::vec2(30, 10), glm::vec2(50, 50) };
-        const std::vector<glm::vec2> triangle_points_201 = { glm::vec2(10, 30), glm::vec2(50, 50), glm::vec2(30, 10) };
-        const std::vector<glm::vec2> triangle_points_120 = { glm::vec2(50, 50), glm::vec2(30, 10), glm::vec2(10, 30) };
-        const std::vector<glm::vec2> triangle_points_210 = { glm::vec2(50, 50), glm::vec2(10, 30), glm::vec2(30, 10) };
+    // SECTION("Triangle y ordering")
+    // {
+    //     // make sure that the triangle_order function correctly orders the triangle points from lowest y to highest y value
+    //     const std::vector<glm::vec2> triangle_points_012 = { { glm::vec2(30, 10), glm::vec2(10, 30), glm::vec2(50, 50) } };
+    //     const std::vector<glm::vec2> triangle_points_021 = { glm::vec2(30, 10), glm::vec2(50, 50), glm::vec2(10, 30) };
+    //     const std::vector<glm::vec2> triangle_points_102 = { glm::vec2(10, 30), glm::vec2(30, 10), glm::vec2(50, 50) };
+    //     const std::vector<glm::vec2> triangle_points_201 = { glm::vec2(10, 30), glm::vec2(50, 50), glm::vec2(30, 10) };
+    //     const std::vector<glm::vec2> triangle_points_120 = { glm::vec2(50, 50), glm::vec2(30, 10), glm::vec2(10, 30) };
+    //     const std::vector<glm::vec2> triangle_points_210 = { glm::vec2(50, 50), glm::vec2(10, 30), glm::vec2(30, 10) };
 
-        const std::vector<glm::vec2> correct = { { glm::vec2(30, 10), glm::vec2(10, 30), glm::vec2(50, 50) } };
+    //     const std::vector<glm::vec2> correct = { { glm::vec2(30, 10), glm::vec2(10, 30), glm::vec2(50, 50) } };
 
-        CHECK(correct == nucleus::utils::rasterizer::triangulize(triangle_points_012));
-        CHECK(correct == nucleus::utils::rasterizer::triangulize(triangle_points_021));
-        CHECK(correct == nucleus::utils::rasterizer::triangulize(triangle_points_102));
-        CHECK(correct == nucleus::utils::rasterizer::triangulize(triangle_points_201));
-        CHECK(correct == nucleus::utils::rasterizer::triangulize(triangle_points_120));
-        CHECK(correct == nucleus::utils::rasterizer::triangulize(triangle_points_210));
-    }
+    //     CHECK(correct == nucleus::utils::rasterizer::triangulize(triangle_points_012));
+    //     CHECK(correct == nucleus::utils::rasterizer::triangulize(triangle_points_021));
+    //     CHECK(correct == nucleus::utils::rasterizer::triangulize(triangle_points_102));
+    //     CHECK(correct == nucleus::utils::rasterizer::triangulize(triangle_points_201));
+    //     CHECK(correct == nucleus::utils::rasterizer::triangulize(triangle_points_120));
+    //     CHECK(correct == nucleus::utils::rasterizer::triangulize(triangle_points_210));
+    // }
 
     SECTION("rasterize triangle")
     {
@@ -320,33 +320,89 @@ TEST_CASE("nucleus/rasterizer")
         image.save(QString("rasterizer_output_line_straight.png"));
     }
 
-    // SECTION("rasterize line diagonal")
-    // {
-    //     const std::vector<glm::vec2> line = { glm::vec2(30.5, 10.5), glm::vec2(50.5, 30.5), glm::vec2(30.5, 50.5), glm::vec2(10.5, 30.5), glm::vec2(30.5, 10.5) };
-    //     // const std::vector<glm::vec2> line = { glm::vec2(5.5, 5.5), glm::vec2(15.5, 10.5) };
-    //     auto size = glm::vec2(64, 64);
-    //     nucleus::Raster<uint8_t> output(size, 0u);
-    //     float distance = 0.0;
-    //     radix::geometry::Aabb2<double> bounds = { { 0, 0 }, size };
+    SECTION("rasterize line minimal lower")
+    {
+        const std::vector<glm::vec2> line = { glm::vec2(2.7, 2.5), glm::vec2(3.7, 1.5) };
+        auto size = glm::vec2(6, 6);
+        nucleus::Raster<uint8_t> output(size, 0u);
+        float distance = 0.0;
+        radix::geometry::Aabb2<double> bounds = { { 0, 0 }, size };
 
-    //     const auto pixel_writer = [&output, bounds](glm::vec2 pos, int) {
-    //         if (bounds.contains(pos))
-    //             // output.pixel(pos) = data == 50 ? 255 : 100;
-    //             output.pixel(pos) = 255;
-    //     };
-    //     nucleus::utils::rasterizer::rasterize_line(pixel_writer, line, distance);
+        const auto pixel_writer = [&output, bounds](glm::vec2 pos, int) {
+            if (bounds.contains(pos))
+                output.pixel(pos) = 255;
+        };
+        nucleus::utils::rasterizer::rasterize_line(pixel_writer, line, distance);
 
-    //     nucleus::Raster<uint8_t> output2(size, 0u);
-    //     const auto pixel_writer2 = [&output2, bounds](glm::vec2 pos, int) {
-    //         if (bounds.contains(pos))
-    //             output2.pixel(pos) = 255;
-    //     };
-    //     nucleus::utils::rasterizer::rasterize_line_sdf(pixel_writer2, line, distance);
+        nucleus::Raster<uint8_t> output2(size, 0u);
+        const auto pixel_writer2 = [&output2, bounds](glm::vec2 pos, int) {
+            if (bounds.contains(pos))
+                output2.pixel(pos) = 255;
+        };
+        nucleus::utils::rasterizer::rasterize_line_sdf(pixel_writer2, line, distance);
 
-    //     CHECK(output.buffer() == output2.buffer());
+        CHECK(output.buffer() == output2.buffer());
 
-    //     // DEBUG: save image (image saved to build/Desktop-Profile/unittests/nucleus)
-    //     auto image = nucleus::tile::conversion::u8raster_2_to_qimage(output, output2);
-    //     image.save(QString("rasterizer_output_line_diagonal.png"));
-    // }
+        // DEBUG: save image (image saved to build/Desktop-Profile/unittests/nucleus)
+        // auto image = nucleus::tile::conversion::u8raster_2_to_qimage(output, output2);
+        // image.save(QString("rasterizer_output_line_minimal_lower.png"));
+    }
+    SECTION("rasterize line minimal upper")
+    {
+
+        const std::vector<glm::vec2> line = { glm::vec2(2.3, 2.5), glm::vec2(3.5, 1.3) };
+        auto size = glm::vec2(6, 6);
+        nucleus::Raster<uint8_t> output(size, 0u);
+        float distance = 0.0;
+        radix::geometry::Aabb2<double> bounds = { { 0, 0 }, size };
+
+        const auto pixel_writer = [&output, bounds](glm::vec2 pos, int) {
+            if (bounds.contains(pos))
+                output.pixel(pos) = 255;
+        };
+        nucleus::utils::rasterizer::rasterize_line(pixel_writer, line, distance);
+
+        nucleus::Raster<uint8_t> output2(size, 0u);
+        const auto pixel_writer2 = [&output2, bounds](glm::vec2 pos, int) {
+            if (bounds.contains(pos))
+                output2.pixel(pos) = 255;
+        };
+        nucleus::utils::rasterizer::rasterize_line_sdf(pixel_writer2, line, distance);
+
+        CHECK(output.buffer() == output2.buffer());
+
+        // DEBUG: save image (image saved to build/Desktop-Profile/unittests/nucleus)
+        // auto image = nucleus::tile::conversion::u8raster_2_to_qimage(output, output2);
+        // image.save(QString("rasterizer_output_line_minimal_upper.png"));
+    }
+
+    SECTION("rasterize line diagonal")
+    {
+        const std::vector<glm::vec2> line = { glm::vec2(30.5, 10.5), glm::vec2(50.5, 30.5), glm::vec2(30.5, 50.5), glm::vec2(10.5, 30.5), glm::vec2(30.5, 10.5) };
+        // const std::vector<glm::vec2> line = { glm::vec2(2.2, 2.5), glm::vec2(3.5, 1.1) };
+        auto size = glm::vec2(64, 64);
+        nucleus::Raster<uint8_t> output(size, 0u);
+        float distance = 0.0;
+        radix::geometry::Aabb2<double> bounds = { { 0, 0 }, size };
+
+        const auto pixel_writer = [&output, bounds](glm::vec2 pos, int) {
+            if (bounds.contains(pos))
+                // output.pixel(pos) = data == 50 ? 255 : 100;
+                output.pixel(pos) = 255;
+        };
+        nucleus::utils::rasterizer::rasterize_line(pixel_writer, line, distance);
+
+        nucleus::Raster<uint8_t> output2(size, 0u);
+        const auto pixel_writer2 = [&output2, bounds](glm::vec2 pos, int) {
+            if (bounds.contains(pos))
+                output2.pixel(pos) = 255;
+        };
+        nucleus::utils::rasterizer::rasterize_line_sdf(pixel_writer2, line, distance);
+
+        CHECK(output.buffer() == output2.buffer());
+
+        // DEBUG: save image (image saved to build/Desktop-Profile/unittests/nucleus)
+        auto image = nucleus::tile::conversion::u8raster_2_to_qimage(output, output2);
+        image.save(QString("rasterizer_output_line_diagonal.png"));
+    }
 }

--- a/unittests/nucleus/rasterizer.cpp
+++ b/unittests/nucleus/rasterizer.cpp
@@ -92,25 +92,25 @@ TEST_CASE("nucleus/rasterizer")
         // }
     }
 
-    // SECTION("Triangle y ordering")
-    // {
-    //     // make sure that the triangle_order function correctly orders the triangle points from lowest y to highest y value
-    //     const std::vector<glm::vec2> triangle_points_012 = { { glm::vec2(30, 10), glm::vec2(10, 30), glm::vec2(50, 50) } };
-    //     const std::vector<glm::vec2> triangle_points_021 = { glm::vec2(30, 10), glm::vec2(50, 50), glm::vec2(10, 30) };
-    //     const std::vector<glm::vec2> triangle_points_102 = { glm::vec2(10, 30), glm::vec2(30, 10), glm::vec2(50, 50) };
-    //     const std::vector<glm::vec2> triangle_points_201 = { glm::vec2(10, 30), glm::vec2(50, 50), glm::vec2(30, 10) };
-    //     const std::vector<glm::vec2> triangle_points_120 = { glm::vec2(50, 50), glm::vec2(30, 10), glm::vec2(10, 30) };
-    //     const std::vector<glm::vec2> triangle_points_210 = { glm::vec2(50, 50), glm::vec2(10, 30), glm::vec2(30, 10) };
+    SECTION("Triangle y ordering")
+    {
+        // make sure that the triangle_order function correctly orders the triangle points from lowest y to highest y value
+        const std::vector<glm::vec2> triangle_points_012 = { { glm::vec2(30, 10), glm::vec2(10, 30), glm::vec2(50, 50) } };
+        const std::vector<glm::vec2> triangle_points_021 = { glm::vec2(30, 10), glm::vec2(50, 50), glm::vec2(10, 30) };
+        const std::vector<glm::vec2> triangle_points_102 = { glm::vec2(10, 30), glm::vec2(30, 10), glm::vec2(50, 50) };
+        const std::vector<glm::vec2> triangle_points_201 = { glm::vec2(10, 30), glm::vec2(50, 50), glm::vec2(30, 10) };
+        const std::vector<glm::vec2> triangle_points_120 = { glm::vec2(50, 50), glm::vec2(30, 10), glm::vec2(10, 30) };
+        const std::vector<glm::vec2> triangle_points_210 = { glm::vec2(50, 50), glm::vec2(10, 30), glm::vec2(30, 10) };
 
-    //     const std::vector<glm::vec2> correct = { { glm::vec2(30, 10), glm::vec2(10, 30), glm::vec2(50, 50) } };
+        const std::vector<glm::vec2> correct = { { glm::vec2(30, 10), glm::vec2(10, 30), glm::vec2(50, 50) } };
 
-    //     CHECK(correct == nucleus::utils::rasterizer::triangulize(triangle_points_012));
-    //     CHECK(correct == nucleus::utils::rasterizer::triangulize(triangle_points_021));
-    //     CHECK(correct == nucleus::utils::rasterizer::triangulize(triangle_points_102));
-    //     CHECK(correct == nucleus::utils::rasterizer::triangulize(triangle_points_201));
-    //     CHECK(correct == nucleus::utils::rasterizer::triangulize(triangle_points_120));
-    //     CHECK(correct == nucleus::utils::rasterizer::triangulize(triangle_points_210));
-    // }
+        CHECK(correct == nucleus::utils::rasterizer::triangulize(triangle_points_012));
+        CHECK(correct == nucleus::utils::rasterizer::triangulize(triangle_points_021));
+        CHECK(correct == nucleus::utils::rasterizer::triangulize(triangle_points_102));
+        CHECK(correct == nucleus::utils::rasterizer::triangulize(triangle_points_201));
+        CHECK(correct == nucleus::utils::rasterizer::triangulize(triangle_points_120));
+        CHECK(correct == nucleus::utils::rasterizer::triangulize(triangle_points_210));
+    }
 
     SECTION("rasterize triangle")
     {

--- a/unittests/nucleus/rasterizer.cpp
+++ b/unittests/nucleus/rasterizer.cpp
@@ -106,68 +106,66 @@ TEST_CASE("nucleus/rasterizer")
         CHECK(correct == nucleus::utils::rasterizer::triangulize(triangle_points_210));
     }
 
-    // SECTION("rasterize triangle")
-    // {
-    //     // two triangles
-    //     const std::vector<glm::vec2> triangles = { glm::vec2(30.5, 10.5), glm::vec2(10.5, 30.5), glm::vec2(50.5, 50.5), glm::vec2(5.5, 5.5), glm::vec2(15.5, 10.5), glm::vec2(5.5, 15.5) };
+    SECTION("rasterize triangle")
+    {
+        // two triangles
+        const std::vector<glm::vec2> triangles = { glm::vec2(30.5, 10.5), glm::vec2(10.5, 30.5), glm::vec2(50.5, 50.5), glm::vec2(5.5, 5.5), glm::vec2(15.5, 10.5), glm::vec2(5.5, 15.5) };
 
-    //     nucleus::Raster<uint8_t> output({ 64, 64 }, 0u);
-    //     const auto pixel_writer = [&output](glm::vec2 pos, int) { output.pixel(pos) = 255; };
-    //     nucleus::utils::rasterizer::rasterize_triangle(pixel_writer, triangles);
+        nucleus::Raster<uint8_t> output({ 64, 64 }, 0u);
+        const auto pixel_writer = [&output](glm::vec2 pos, int) { output.pixel(pos) = 255; };
+        nucleus::utils::rasterizer::rasterize_triangle(pixel_writer, triangles);
 
-    //     nucleus::Raster<uint8_t> output2({ 64, 64 }, 0u);
-    //     const auto pixel_writer2 = [&output2](glm::vec2 pos, int) { output2.pixel(pos) = 255; };
-    //     nucleus::utils::rasterizer::rasterize_triangle_sdf(pixel_writer2, triangles, 0, output2.size());
+        nucleus::Raster<uint8_t> output2({ 64, 64 }, 0u);
+        const auto pixel_writer2 = [&output2](glm::vec2 pos, int) { output2.pixel(pos) = 255; };
+        nucleus::utils::rasterizer::rasterize_triangle_sdf(pixel_writer2, triangles, 0, output2.size());
 
-    //     CHECK(output.buffer() == output2.buffer());
+        CHECK(output.buffer() == output2.buffer());
 
-    //     // DEBUG: save image (image saved to build/Desktop-Profile/unittests/nucleus)
-    //     // auto image = nucleus::tile::conversion::u8raster_to_qimage(output);
-    //     // image.save(QString("rasterizer_output.png"));
-    //     // auto image2 = nucleus::tile::conversion::u8raster_to_qimage(output2);
-    //     // image2.save(QString("rasterizer_output_sdf.png"));
-    // }
+        // DEBUG: save image (image saved to build/Desktop-Profile/unittests/nucleus)
+        auto image = nucleus::tile::conversion::u8raster_2_to_qimage(output, output2);
+        image.save(QString("rasterizer_output.png"));
+    }
 
-    // SECTION("rasterize triangle small")
-    // {
-    //     const std::vector<glm::vec2> triangles_small = { glm::vec2(2, 2), glm::vec2(1, 3), glm::vec2(3.8, 3.8) };
-    //     nucleus::Raster<uint8_t> output({ 6, 6 }, 0u);
-    //     const auto pixel_writer = [&output](glm::vec2 pos, int) { output.pixel(pos) = 255; };
-    //     nucleus::utils::rasterizer::rasterize_triangle(pixel_writer, triangles_small);
+    SECTION("rasterize triangle small")
+    {
+        const std::vector<glm::vec2> triangles_small = { glm::vec2(2, 2), glm::vec2(1, 3), glm::vec2(3.8, 3.8) };
+        nucleus::Raster<uint8_t> output({ 6, 6 }, 0u);
+        const auto pixel_writer = [&output](glm::vec2 pos, int) { output.pixel(pos) = 255; };
+        nucleus::utils::rasterizer::rasterize_triangle(pixel_writer, triangles_small);
 
-    //     nucleus::Raster<uint8_t> output2({ 6, 6 }, 0u);
-    //     const auto pixel_writer2 = [&output2](glm::vec2 pos, int) { output2.pixel(pos) = 255; };
-    //     nucleus::utils::rasterizer::rasterize_triangle_sdf(pixel_writer2, triangles_small, 0, output2.size());
+        nucleus::Raster<uint8_t> output2({ 6, 6 }, 0u);
+        const auto pixel_writer2 = [&output2](glm::vec2 pos, int) { output2.pixel(pos) = 255; };
+        nucleus::utils::rasterizer::rasterize_triangle_sdf(pixel_writer2, triangles_small, 0, output2.size());
 
-    //     CHECK(output.buffer() == output2.buffer());
+        CHECK(output.buffer() == output2.buffer());
 
-    //     // DEBUG: save image (image saved to build/Desktop-Profile/unittests/nucleus)
-    //     // auto image = nucleus::tile::conversion::u8raster_to_qimage(output);
-    //     // image.save(QString("rasterizer_output_small.png"));
-    //     // auto image2 = nucleus::tile::conversion::u8raster_to_qimage(output2);
-    //     // image2.save(QString("rasterizer_output_small_sdf.png"));
-    // }
+        // DEBUG: save image (image saved to build/Desktop-Profile/unittests/nucleus)
+        // auto image = nucleus::tile::conversion::u8raster_to_qimage(output);
+        // image.save(QString("rasterizer_output_small.png"));
+        // auto image2 = nucleus::tile::conversion::u8raster_to_qimage(output2);
+        // image2.save(QString("rasterizer_output_small_sdf.png"));
+    }
 
-    // SECTION("rasterize triangle smallest")
-    // {
-    //     // less than one pixel
-    //     const std::vector<glm::vec2> triangles_smallest = { glm::vec2(30.4, 30.4), glm::vec2(30.8, 30.6), glm::vec2(30.8, 30.8) };
-    //     nucleus::Raster<uint8_t> output({ 64, 64 }, 0u);
-    //     const auto pixel_writer = [&output](glm::vec2 pos, int) { output.pixel(pos) = 255; };
-    //     nucleus::utils::rasterizer::rasterize_triangle(pixel_writer, triangles_smallest);
+    SECTION("rasterize triangle smallest")
+    {
+        // less than one pixel
+        const std::vector<glm::vec2> triangles_smallest = { glm::vec2(30.4, 30.4), glm::vec2(30.8, 30.6), glm::vec2(30.8, 30.8) };
+        nucleus::Raster<uint8_t> output({ 64, 64 }, 0u);
+        const auto pixel_writer = [&output](glm::vec2 pos, int) { output.pixel(pos) = 255; };
+        nucleus::utils::rasterizer::rasterize_triangle(pixel_writer, triangles_smallest);
 
-    //     nucleus::Raster<uint8_t> output2({ 64, 64 }, 0u);
-    //     const auto pixel_writer2 = [&output2](glm::vec2 pos, int) { output2.pixel(pos) = 255; };
-    //     nucleus::utils::rasterizer::rasterize_triangle_sdf(pixel_writer2, triangles_smallest, 0, output2.size());
+        nucleus::Raster<uint8_t> output2({ 64, 64 }, 0u);
+        const auto pixel_writer2 = [&output2](glm::vec2 pos, int) { output2.pixel(pos) = 255; };
+        nucleus::utils::rasterizer::rasterize_triangle_sdf(pixel_writer2, triangles_smallest, 0, output2.size());
 
-    //     CHECK(output.buffer() == output2.buffer());
+        CHECK(output.buffer() == output2.buffer());
 
-    //     // DEBUG: save image (image saved to build/Desktop-Profile/unittests/nucleus)
-    //     // auto image = nucleus::tile::conversion::u8raster_to_qimage(output);
-    //     // image.save(QString("rasterizer_output_smallest.png"));
-    //     // auto image2 = nucleus::tile::conversion::u8raster_to_qimage(output2);
-    //     // image2.save(QString("rasterizer_output_smallest_sdf.png"));
-    // }
+        // DEBUG: save image (image saved to build/Desktop-Profile/unittests/nucleus)
+        // auto image = nucleus::tile::conversion::u8raster_to_qimage(output);
+        // image.save(QString("rasterizer_output_smallest.png"));
+        // auto image2 = nucleus::tile::conversion::u8raster_to_qimage(output2);
+        // image2.save(QString("rasterizer_output_smallest_sdf.png"));
+    }
 
     SECTION("rasterize triangle enlarged endcaps only")
     {
@@ -182,7 +180,6 @@ TEST_CASE("nucleus/rasterizer")
             if (bounds.contains(pos))
                 output.pixel(pos) = 255;
         };
-        // nucleus::utils::rasterizer::rasterize_triangle(pixel_writer, triangles, distance);
         nucleus::utils::rasterizer::details::add_end_cap(pixel_writer, triangles[0], 1, distance);
         nucleus::utils::rasterizer::details::add_end_cap(pixel_writer, triangles[1], 1, distance);
         nucleus::utils::rasterizer::details::add_end_cap(pixel_writer, triangles[2], 1, distance);
@@ -216,9 +213,6 @@ TEST_CASE("nucleus/rasterizer")
                 output.pixel(pos) = 255;
         };
         nucleus::utils::rasterizer::rasterize_triangle(pixel_writer, triangles, distance);
-        // nucleus::utils::rasterizer::details::add_end_cap(pixel_writer, triangles[0], 1, distance);
-        // nucleus::utils::rasterizer::details::add_end_cap(pixel_writer, triangles[1], 1, distance);
-        // nucleus::utils::rasterizer::details::add_end_cap(pixel_writer, triangles[2], 1, distance);
 
         nucleus::Raster<uint8_t> output2(size, 0u);
         const auto pixel_writer2 = [&output2, bounds](glm::vec2 pos, int) {

--- a/unittests/nucleus/rasterizer.cpp
+++ b/unittests/nucleus/rasterizer.cpp
@@ -128,8 +128,8 @@ TEST_CASE("nucleus/rasterizer")
         CHECK(output.buffer() == output2.buffer());
 
         // DEBUG: save image (image saved to build/Desktop-Profile/unittests/nucleus)
-        auto image = nucleus::tile::conversion::u8raster_2_to_qimage(output, output2);
-        image.save(QString("rasterizer_output.png"));
+        // auto image = nucleus::tile::conversion::u8raster_2_to_qimage(output, output2);
+        // image.save(QString("rasterizer_output.png"));
     }
 
     SECTION("rasterize triangle small")
@@ -146,8 +146,8 @@ TEST_CASE("nucleus/rasterizer")
         CHECK(output.buffer() == output2.buffer());
 
         // DEBUG: save image (image saved to build/Desktop-Profile/unittests/nucleus)
-        auto image = nucleus::tile::conversion::u8raster_2_to_qimage(output, output2);
-        image.save(QString("rasterizer_output_small.png"));
+        // auto image = nucleus::tile::conversion::u8raster_2_to_qimage(output, output2);
+        // image.save(QString("rasterizer_output_small.png"));
     }
 
     SECTION("rasterize triangle smallest")
@@ -231,8 +231,8 @@ TEST_CASE("nucleus/rasterizer")
         CHECK(output.buffer() == output2.buffer());
 
         // DEBUG: save image (image saved to build/Desktop-Profile/unittests/nucleus)
-        auto image = nucleus::tile::conversion::u8raster_2_to_qimage(output, output2);
-        image.save(QString("rasterizer_output_enlarged.png"));
+        // auto image = nucleus::tile::conversion::u8raster_2_to_qimage(output, output2);
+        // image.save(QString("rasterizer_output_enlarged.png"));
     }
 
     SECTION("rasterize triangle horizontal")
@@ -292,6 +292,107 @@ TEST_CASE("nucleus/rasterizer")
     //     image.save(QString("rasterizer_output_enlarged_narrow.png"));
     // }
 
+    SECTION("rasterize triangle start/end y")
+    {
+        const std::vector<glm::vec2> triangles = { // down to right
+            glm::vec2(2.7, 1.5),
+            glm::vec2(3.7, 2.5),
+            glm::vec2(3.7, 2.7),
+            // down to left
+            glm::vec2(8.7, 1.5),
+            glm::vec2(7.7, 2.5),
+            glm::vec2(7.7, 2.7),
+
+            // 1 lines
+            // down to right
+            glm::vec2(3.5, 7.3),
+            glm::vec2(26.5, 7.5),
+            glm::vec2(24.5, 7.6),
+            // down to left
+            glm::vec2(26.5, 12.3),
+            glm::vec2(3.5, 12.5),
+            glm::vec2(5.5, 12.6),
+
+            // 2 lines
+            // down to right
+            glm::vec2(3.5, 16.7),
+            glm::vec2(6.5, 17.5),
+            glm::vec2(4.5, 17.6),
+            // down to left
+            glm::vec2(6.5, 21.7),
+            glm::vec2(3.5, 22.5),
+            glm::vec2(5.5, 22.6)
+        };
+
+        auto size = glm::vec2(30, 30);
+        nucleus::Raster<uint8_t> output(size, 0u);
+        float distance = 0.0;
+        radix::geometry::Aabb2<double> bounds = { { 0, 0 }, size };
+
+        const auto pixel_writer = [&output, bounds](glm::vec2 pos, int) {
+            if (bounds.contains(pos))
+                output.pixel(pos) = 255;
+        };
+        nucleus::utils::rasterizer::rasterize_triangle(pixel_writer, triangles, distance);
+
+        nucleus::Raster<uint8_t> output2(size, 0u);
+        const auto pixel_writer2 = [&output2, bounds](glm::vec2 pos, int) {
+            if (bounds.contains(pos))
+                output2.pixel(pos) = 255;
+        };
+        nucleus::utils::rasterizer::rasterize_triangle_sdf(pixel_writer2, triangles, distance);
+
+        CHECK(output.buffer() == output2.buffer());
+
+        // DEBUG: save image (image saved to build/Desktop-Profile/unittests/nucleus)
+        // auto image = nucleus::tile::conversion::u8raster_2_to_qimage(output, output2);
+        // image.save(QString("rasterizer_output_triangle_start_end.png"));
+    }
+
+    SECTION("rasterize line start/end y")
+    {
+        const std::vector<glm::vec2> line_lower_min = { glm::vec2(2.7, 2.5), glm::vec2(3.7, 1.5) };
+        const std::vector<glm::vec2> line_upper_min = { glm::vec2(7.3, 2.5), glm::vec2(8.5, 1.3) };
+        const std::vector<glm::vec2> line_left_to_right_1pixel = { glm::vec2(2.3, 7.3), glm::vec2(28.5, 7.7) };
+        const std::vector<glm::vec2> line_right_to_left_1pixel = { glm::vec2(2.3, 12.7), glm::vec2(28.5, 12.3) };
+        const std::vector<glm::vec2> line_left_to_right_2pixel = { glm::vec2(2.3, 17.3), glm::vec2(6.5, 18.7) };
+        const std::vector<glm::vec2> line_right_to_left_2pixel = { glm::vec2(2.3, 23.7), glm::vec2(6.5, 22.3) };
+
+        auto size = glm::vec2(30, 30);
+        nucleus::Raster<uint8_t> output(size, 0u);
+        float distance = 0.0;
+        radix::geometry::Aabb2<double> bounds = { { 0, 0 }, size };
+
+        const auto pixel_writer = [&output, bounds](glm::vec2 pos, int) {
+            if (bounds.contains(pos))
+                output.pixel(pos) = 255;
+        };
+        nucleus::utils::rasterizer::rasterize_line(pixel_writer, line_lower_min, distance);
+        nucleus::utils::rasterizer::rasterize_line(pixel_writer, line_upper_min, distance);
+        nucleus::utils::rasterizer::rasterize_line(pixel_writer, line_left_to_right_1pixel, distance);
+        nucleus::utils::rasterizer::rasterize_line(pixel_writer, line_right_to_left_1pixel, distance);
+        nucleus::utils::rasterizer::rasterize_line(pixel_writer, line_left_to_right_2pixel, distance);
+        nucleus::utils::rasterizer::rasterize_line(pixel_writer, line_right_to_left_2pixel, distance);
+
+        nucleus::Raster<uint8_t> output2(size, 0u);
+        const auto pixel_writer2 = [&output2, bounds](glm::vec2 pos, int) {
+            if (bounds.contains(pos))
+                output2.pixel(pos) = 255;
+        };
+        nucleus::utils::rasterizer::rasterize_line_sdf(pixel_writer2, line_lower_min, distance);
+        nucleus::utils::rasterizer::rasterize_line_sdf(pixel_writer2, line_upper_min, distance);
+        nucleus::utils::rasterizer::rasterize_line_sdf(pixel_writer2, line_left_to_right_1pixel, distance);
+        nucleus::utils::rasterizer::rasterize_line_sdf(pixel_writer2, line_right_to_left_1pixel, distance);
+        nucleus::utils::rasterizer::rasterize_line_sdf(pixel_writer2, line_left_to_right_2pixel, distance);
+        nucleus::utils::rasterizer::rasterize_line_sdf(pixel_writer2, line_right_to_left_2pixel, distance);
+
+        CHECK(output.buffer() == output2.buffer());
+
+        // DEBUG: save image (image saved to build/Desktop-Profile/unittests/nucleus)
+        // auto image = nucleus::tile::conversion::u8raster_2_to_qimage(output, output2);
+        // image.save(QString("rasterizer_output_line_start_end.png"));
+    }
+
     SECTION("rasterize line straight")
     {
         const std::vector<glm::vec2> line = { glm::vec2(10.5, 10.5), glm::vec2(10.5, 50.5), glm::vec2(50.5, 50.5), glm::vec2(50.5, 10.5), glm::vec2(10.5, 10.5) };
@@ -316,70 +417,13 @@ TEST_CASE("nucleus/rasterizer")
         CHECK(output.buffer() == output2.buffer());
 
         // DEBUG: save image (image saved to build/Desktop-Profile/unittests/nucleus)
-        auto image = nucleus::tile::conversion::u8raster_2_to_qimage(output, output2);
-        image.save(QString("rasterizer_output_line_straight.png"));
-    }
-
-    SECTION("rasterize line minimal lower")
-    {
-        const std::vector<glm::vec2> line = { glm::vec2(2.7, 2.5), glm::vec2(3.7, 1.5) };
-        auto size = glm::vec2(6, 6);
-        nucleus::Raster<uint8_t> output(size, 0u);
-        float distance = 0.0;
-        radix::geometry::Aabb2<double> bounds = { { 0, 0 }, size };
-
-        const auto pixel_writer = [&output, bounds](glm::vec2 pos, int) {
-            if (bounds.contains(pos))
-                output.pixel(pos) = 255;
-        };
-        nucleus::utils::rasterizer::rasterize_line(pixel_writer, line, distance);
-
-        nucleus::Raster<uint8_t> output2(size, 0u);
-        const auto pixel_writer2 = [&output2, bounds](glm::vec2 pos, int) {
-            if (bounds.contains(pos))
-                output2.pixel(pos) = 255;
-        };
-        nucleus::utils::rasterizer::rasterize_line_sdf(pixel_writer2, line, distance);
-
-        CHECK(output.buffer() == output2.buffer());
-
-        // DEBUG: save image (image saved to build/Desktop-Profile/unittests/nucleus)
         // auto image = nucleus::tile::conversion::u8raster_2_to_qimage(output, output2);
-        // image.save(QString("rasterizer_output_line_minimal_lower.png"));
-    }
-    SECTION("rasterize line minimal upper")
-    {
-
-        const std::vector<glm::vec2> line = { glm::vec2(2.3, 2.5), glm::vec2(3.5, 1.3) };
-        auto size = glm::vec2(6, 6);
-        nucleus::Raster<uint8_t> output(size, 0u);
-        float distance = 0.0;
-        radix::geometry::Aabb2<double> bounds = { { 0, 0 }, size };
-
-        const auto pixel_writer = [&output, bounds](glm::vec2 pos, int) {
-            if (bounds.contains(pos))
-                output.pixel(pos) = 255;
-        };
-        nucleus::utils::rasterizer::rasterize_line(pixel_writer, line, distance);
-
-        nucleus::Raster<uint8_t> output2(size, 0u);
-        const auto pixel_writer2 = [&output2, bounds](glm::vec2 pos, int) {
-            if (bounds.contains(pos))
-                output2.pixel(pos) = 255;
-        };
-        nucleus::utils::rasterizer::rasterize_line_sdf(pixel_writer2, line, distance);
-
-        CHECK(output.buffer() == output2.buffer());
-
-        // DEBUG: save image (image saved to build/Desktop-Profile/unittests/nucleus)
-        // auto image = nucleus::tile::conversion::u8raster_2_to_qimage(output, output2);
-        // image.save(QString("rasterizer_output_line_minimal_upper.png"));
+        // image.save(QString("rasterizer_output_line_straight.png"));
     }
 
     SECTION("rasterize line diagonal")
     {
         const std::vector<glm::vec2> line = { glm::vec2(30.5, 10.5), glm::vec2(50.5, 30.5), glm::vec2(30.5, 50.5), glm::vec2(10.5, 30.5), glm::vec2(30.5, 10.5) };
-        // const std::vector<glm::vec2> line = { glm::vec2(2.2, 2.5), glm::vec2(3.5, 1.1) };
         auto size = glm::vec2(64, 64);
         nucleus::Raster<uint8_t> output(size, 0u);
         float distance = 0.0;
@@ -387,7 +431,6 @@ TEST_CASE("nucleus/rasterizer")
 
         const auto pixel_writer = [&output, bounds](glm::vec2 pos, int) {
             if (bounds.contains(pos))
-                // output.pixel(pos) = data == 50 ? 255 : 100;
                 output.pixel(pos) = 255;
         };
         nucleus::utils::rasterizer::rasterize_line(pixel_writer, line, distance);
@@ -402,7 +445,64 @@ TEST_CASE("nucleus/rasterizer")
         CHECK(output.buffer() == output2.buffer());
 
         // DEBUG: save image (image saved to build/Desktop-Profile/unittests/nucleus)
-        auto image = nucleus::tile::conversion::u8raster_2_to_qimage(output, output2);
-        image.save(QString("rasterizer_output_line_diagonal.png"));
+        // auto image = nucleus::tile::conversion::u8raster_2_to_qimage(output, output2);
+        // image.save(QString("rasterizer_output_line_diagonal.png"));
+    }
+
+    SECTION("rasterize line straight enlarged")
+    {
+        const std::vector<glm::vec2> line = { glm::vec2(10.5, 10.5), glm::vec2(10.5, 50.5), glm::vec2(50.5, 50.5), glm::vec2(50.5, 10.5), glm::vec2(10.5, 10.5) };
+        auto size = glm::vec2(64, 64);
+        nucleus::Raster<uint8_t> output(size, 0u);
+        float distance = 2.0;
+        radix::geometry::Aabb2<double> bounds = { { 0, 0 }, size };
+
+        const auto pixel_writer = [&output, bounds](glm::vec2 pos, int) {
+            if (bounds.contains(pos))
+                output.pixel(pos) = 255;
+        };
+        nucleus::utils::rasterizer::rasterize_line(pixel_writer, line, distance);
+
+        nucleus::Raster<uint8_t> output2(size, 0u);
+        const auto pixel_writer2 = [&output2, bounds](glm::vec2 pos, int) {
+            if (bounds.contains(pos))
+                output2.pixel(pos) = 255;
+        };
+        nucleus::utils::rasterizer::rasterize_line_sdf(pixel_writer2, line, distance);
+
+        CHECK(output.buffer() == output2.buffer());
+
+        // DEBUG: save image (image saved to build/Desktop-Profile/unittests/nucleus)
+        // auto image = nucleus::tile::conversion::u8raster_2_to_qimage(output, output2);
+        // image.save(QString("rasterizer_output_line_straight_enlarged.png"));
+    }
+
+    SECTION("rasterize line diagonal enlarged")
+    {
+        const std::vector<glm::vec2> line = { glm::vec2(30.5, 10.5), glm::vec2(50.5, 30.5), glm::vec2(30.5, 50.5), glm::vec2(10.5, 30.5), glm::vec2(30.5, 10.5) };
+        // const std::vector<glm::vec2> line = { glm::vec2(30.5, 10.5), glm::vec2(50.5, 30.5) };
+        auto size = glm::vec2(64, 64);
+        nucleus::Raster<uint8_t> output(size, 0u);
+        float distance = 2.0;
+        radix::geometry::Aabb2<double> bounds = { { 0, 0 }, size };
+
+        const auto pixel_writer = [&output, bounds](glm::vec2 pos, int) {
+            if (bounds.contains(pos))
+                output.pixel(pos) = 255;
+        };
+        nucleus::utils::rasterizer::rasterize_line(pixel_writer, line, distance);
+
+        nucleus::Raster<uint8_t> output2(size, 0u);
+        const auto pixel_writer2 = [&output2, bounds](glm::vec2 pos, int) {
+            if (bounds.contains(pos))
+                output2.pixel(pos) = 255;
+        };
+        nucleus::utils::rasterizer::rasterize_line_sdf(pixel_writer2, line, distance);
+
+        CHECK(output.buffer() == output2.buffer());
+
+        // DEBUG: save image (image saved to build/Desktop-Profile/unittests/nucleus)
+        // auto image = nucleus::tile::conversion::u8raster_2_to_qimage(output, output2);
+        // image.save(QString("rasterizer_output_line_diagonal_enlarged.png"));
     }
 }

--- a/unittests/nucleus/rasterizer.cpp
+++ b/unittests/nucleus/rasterizer.cpp
@@ -20,7 +20,7 @@
 #include <QSignalSpy>
 #include <catch2/catch_test_macros.hpp>
 
-#include <CDT.h>
+// #include <CDT.h>
 
 #include "nucleus/Raster.h"
 // #include "nucleus/tile/conversion.h"
@@ -36,61 +36,61 @@ TEST_CASE("nucleus/rasterizer")
     // but future changes might cause problems, when there shouldn't be problems
     // so if a test fails check the debug images to see what exactly went wrong.
 
-    SECTION("Triangulation")
-    {
-        // 5 point polygon
-        // basically a square where one side contains an inward facing triangle
-        // a triangulation algorithm should be able to discern that 3 triangles are needed to construct this shape
-        const std::vector<glm::vec2> points = { glm::vec2(0, 0), glm::vec2(1, 1), glm::vec2(0, 2), glm::vec2(2, 2), glm::vec2(2, 0) };
-        const std::vector<glm::ivec2> edges = { glm::ivec2(0, 1), glm::ivec2(1, 2), glm::ivec2(2, 3), glm::ivec2(3, 4), glm::ivec2(4, 0) };
+    // SECTION("Triangulation")
+    // {
+    //     // 5 point polygon
+    //     // basically a square where one side contains an inward facing triangle
+    //     // a triangulation algorithm should be able to discern that 3 triangles are needed to construct this shape
+    //     const std::vector<glm::vec2> points = { glm::vec2(0, 0), glm::vec2(1, 1), glm::vec2(0, 2), glm::vec2(2, 2), glm::vec2(2, 0) };
+    //     const std::vector<glm::ivec2> edges = { glm::ivec2(0, 1), glm::ivec2(1, 2), glm::ivec2(2, 3), glm::ivec2(3, 4), glm::ivec2(4, 0) };
 
-        CDT::Triangulation<double> cdt;
-        cdt.insertVertices(points.begin(), points.end(), [](const glm::vec2& p) { return p.x; }, [](const glm::vec2& p) { return p.y; });
-        cdt.insertEdges(edges.begin(), edges.end(), [](const glm::ivec2& p) { return p.x; }, [](const glm::ivec2& p) { return p.y; });
-        cdt.eraseOuterTrianglesAndHoles();
+    //     CDT::Triangulation<double> cdt;
+    //     cdt.insertVertices(points.begin(), points.end(), [](const glm::vec2& p) { return p.x; }, [](const glm::vec2& p) { return p.y; });
+    //     cdt.insertEdges(edges.begin(), edges.end(), [](const glm::ivec2& p) { return p.x; }, [](const glm::ivec2& p) { return p.y; });
+    //     cdt.eraseOuterTrianglesAndHoles();
 
-        auto tri = cdt.triangles;
-        auto vert = cdt.vertices;
+    //     auto tri = cdt.triangles;
+    //     auto vert = cdt.vertices;
 
-        // check if only 3 triangles have been found
-        CHECK(tri.size() == 3);
+    //     // check if only 3 triangles have been found
+    //     CHECK(tri.size() == 3);
 
-        // 1st triangle
-        CHECK(vert[tri[0].vertices[0]].x == 0.0);
-        CHECK(vert[tri[0].vertices[0]].y == 2.0);
-        CHECK(vert[tri[0].vertices[1]].x == 1.0);
-        CHECK(vert[tri[0].vertices[1]].y == 1.0);
-        CHECK(vert[tri[0].vertices[2]].x == 2.0);
-        CHECK(vert[tri[0].vertices[2]].y == 2.0);
+    //     // 1st triangle
+    //     CHECK(vert[tri[0].vertices[0]].x == 0.0);
+    //     CHECK(vert[tri[0].vertices[0]].y == 2.0);
+    //     CHECK(vert[tri[0].vertices[1]].x == 1.0);
+    //     CHECK(vert[tri[0].vertices[1]].y == 1.0);
+    //     CHECK(vert[tri[0].vertices[2]].x == 2.0);
+    //     CHECK(vert[tri[0].vertices[2]].y == 2.0);
 
-        // 2nd triangle
-        CHECK(vert[tri[1].vertices[0]].x == 1.0);
-        CHECK(vert[tri[1].vertices[0]].y == 1.0);
-        CHECK(vert[tri[1].vertices[1]].x == 2.0);
-        CHECK(vert[tri[1].vertices[1]].y == 0.0);
-        CHECK(vert[tri[1].vertices[2]].x == 2.0);
-        CHECK(vert[tri[1].vertices[2]].y == 2.0);
+    //     // 2nd triangle
+    //     CHECK(vert[tri[1].vertices[0]].x == 1.0);
+    //     CHECK(vert[tri[1].vertices[0]].y == 1.0);
+    //     CHECK(vert[tri[1].vertices[1]].x == 2.0);
+    //     CHECK(vert[tri[1].vertices[1]].y == 0.0);
+    //     CHECK(vert[tri[1].vertices[2]].x == 2.0);
+    //     CHECK(vert[tri[1].vertices[2]].y == 2.0);
 
-        // 3rd triangle
-        CHECK(vert[tri[2].vertices[0]].x == 1.0);
-        CHECK(vert[tri[2].vertices[0]].y == 1.0);
-        CHECK(vert[tri[2].vertices[1]].x == 0.0);
-        CHECK(vert[tri[2].vertices[1]].y == 0.0);
-        CHECK(vert[tri[2].vertices[2]].x == 2.0);
-        CHECK(vert[tri[2].vertices[2]].y == 0.0);
+    //     // 3rd triangle
+    //     CHECK(vert[tri[2].vertices[0]].x == 1.0);
+    //     CHECK(vert[tri[2].vertices[0]].y == 1.0);
+    //     CHECK(vert[tri[2].vertices[1]].x == 0.0);
+    //     CHECK(vert[tri[2].vertices[1]].y == 0.0);
+    //     CHECK(vert[tri[2].vertices[2]].x == 2.0);
+    //     CHECK(vert[tri[2].vertices[2]].y == 0.0);
 
-        // DEBUG print out all the points of the triangles (to check what might have went wrong)
-        // for (std::size_t i = 0; i < tri.size(); i++) {
-        //     printf("Triangle points: [[%f, %f], [%f, %f], [%f, %f]]\n",
-        //         vert[tri[i].vertices[0]].x, // x0
-        //         vert[tri[i].vertices[0]].y, // y0
-        //         vert[tri[i].vertices[1]].x, // x1
-        //         vert[tri[i].vertices[1]].y, // y1
-        //         vert[tri[i].vertices[2]].x, // x2
-        //         vert[tri[i].vertices[2]].y // y2
-        //     );
-        // }
-    }
+    //     // DEBUG print out all the points of the triangles (to check what might have went wrong)
+    //     // for (std::size_t i = 0; i < tri.size(); i++) {
+    //     //     printf("Triangle points: [[%f, %f], [%f, %f], [%f, %f]]\n",
+    //     //         vert[tri[i].vertices[0]].x, // x0
+    //     //         vert[tri[i].vertices[0]].y, // y0
+    //     //         vert[tri[i].vertices[1]].x, // x1
+    //     //         vert[tri[i].vertices[1]].y, // y1
+    //     //         vert[tri[i].vertices[2]].x, // x2
+    //     //         vert[tri[i].vertices[2]].y // y2
+    //     //     );
+    //     // }
+    // }
 
     // SECTION("Triangle y ordering")
     // {

--- a/unittests/nucleus/rasterizer.cpp
+++ b/unittests/nucleus/rasterizer.cpp
@@ -196,18 +196,13 @@ TEST_CASE("nucleus/rasterizer")
 
     SECTION("rasterize triangle enlarged")
     {
-        // less than one pixel
         const std::vector<glm::vec2> triangles = { glm::vec2(30.5, 10.5),
             glm::vec2(10.5, 30.5),
             glm::vec2(50.5, 50.5),
 
             glm::vec2(5.5, 5.5),
             glm::vec2(15.5, 10.5),
-            glm::vec2(5.5, 15.5),
-
-            glm::vec2(15.5, 50.5),
-            glm::vec2(5.5, 50.5),
-            glm::vec2(10.5, 60.5) };
+            glm::vec2(5.5, 15.5) };
         // const std::vector<glm::vec2> triangles = { glm::vec2(5.35, 5.35), glm::vec2(5.40, 5.40), glm::vec2(5.45, 5.35) };
         auto size = glm::vec2(64, 64);
         nucleus::Raster<uint8_t> output(size, 0u);
@@ -232,5 +227,61 @@ TEST_CASE("nucleus/rasterizer")
         // DEBUG: save image (image saved to build/Desktop-Profile/unittests/nucleus)
         auto image = nucleus::tile::conversion::u8raster_2_to_qimage(output, output2);
         image.save(QString("rasterizer_output_enlarged.png"));
+    }
+
+    SECTION("rasterize triangle horizontal")
+    {
+        const std::vector<glm::vec2> triangles = { glm::vec2(30.5, 10.5), glm::vec2(45.5, 45.5), glm::vec2(10.5, 45.5) };
+        auto size = glm::vec2(64, 64);
+        nucleus::Raster<uint8_t> output(size, 0u);
+        float distance = 4.0;
+        radix::geometry::Aabb2<double> bounds = { { 0, 0 }, size };
+
+        const auto pixel_writer = [&output, bounds](glm::vec2 pos, int) {
+            if (bounds.contains(pos))
+                output.pixel(pos) = 255;
+        };
+        nucleus::utils::rasterizer::rasterize_triangle(pixel_writer, triangles, distance);
+
+        nucleus::Raster<uint8_t> output2(size, 0u);
+        const auto pixel_writer2 = [&output2, bounds](glm::vec2 pos, int) {
+            if (bounds.contains(pos))
+                output2.pixel(pos) = 255;
+        };
+        nucleus::utils::rasterizer::rasterize_triangle_sdf(pixel_writer2, triangles, distance, output2.size());
+
+        CHECK(output.buffer() == output2.buffer());
+
+        // DEBUG: save image (image saved to build/Desktop-Profile/unittests/nucleus)
+        auto image = nucleus::tile::conversion::u8raster_2_to_qimage(output, output2);
+        image.save(QString("rasterizer_output_enlarged_horizontal.png"));
+    }
+
+    SECTION("rasterize triangle narrow")
+    {
+        const std::vector<glm::vec2> triangles = { glm::vec2(6.5, 6.5), glm::vec2(6.5, 10.5), glm::vec2(64.5, 8.5) };
+        auto size = glm::vec2(64, 64);
+        nucleus::Raster<uint8_t> output(size, 0u);
+        float distance = 2.0;
+        radix::geometry::Aabb2<double> bounds = { { 0, 0 }, size };
+
+        const auto pixel_writer = [&output, bounds](glm::vec2 pos, int) {
+            if (bounds.contains(pos))
+                output.pixel(pos) = 255;
+        };
+        nucleus::utils::rasterizer::rasterize_triangle(pixel_writer, triangles, distance);
+
+        nucleus::Raster<uint8_t> output2(size, 0u);
+        const auto pixel_writer2 = [&output2, bounds](glm::vec2 pos, int) {
+            if (bounds.contains(pos))
+                output2.pixel(pos) = 255;
+        };
+        nucleus::utils::rasterizer::rasterize_triangle_sdf(pixel_writer2, triangles, distance, output2.size());
+
+        CHECK(output.buffer() == output2.buffer());
+
+        // DEBUG: save image (image saved to build/Desktop-Profile/unittests/nucleus)
+        auto image = nucleus::tile::conversion::u8raster_2_to_qimage(output, output2);
+        image.save(QString("rasterizer_output_enlarged_narrow.png"));
     }
 }


### PR DESCRIPTION
usage example: https://github.com/LucasDworschak/renderer/blob/13e40bb263907d87e878c1d04b8caeea217494bf/nucleus/vector_layer/Preprocessor.cpp#L91

todos (from the top of my head):

- [ ] api change to draw polygons directly (i've seen that you supply a triangle index. christian doesn't need it, and to my understanding it looses its meaning when only a polygon is supplied. please decide what to do with that without adding too much work. i'm now also ok with just keeping the triangle api, but if there is a quick fix, then please do it. maybe just wrapping the lambda? shouldn't be slower, as the compiler sees through all of it. 
- [ ] document the interface: what's the signature of PixelWriterFunction, which coordinates does it take (to my understanding pixel coordinates), what is the index (to my understanding it's the triangle index).
- [ ] move *sdf functions to the unit tests
- [ ] anything i forgot?