### PR TITLE
suppress -Wmissing-field-initializers on GCC/Clang

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -103,6 +103,10 @@ if (ALP_USE_LLVM_LINKER)
     string(APPEND CMAKE_EXE_LINKER_FLAGS " -fuse-ld=lld")
 endif()
 
+if (CMAKE_CXX_COMPILER_ID MATCHES "GNU|Clang")
+    add_compile_options(-Wno-missing-field-initializers)
+endif()
+
 # Disable Qt debug output in release builds
 if(CMAKE_BUILD_TYPE STREQUAL "Release")
     add_compile_definitions(QT_NO_DEBUG_OUTPUT)

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -103,10 +103,6 @@ if (ALP_USE_LLVM_LINKER)
     string(APPEND CMAKE_EXE_LINKER_FLAGS " -fuse-ld=lld")
 endif()
 
-if (CMAKE_CXX_COMPILER_ID MATCHES "GNU|Clang")
-    add_compile_options(-Wno-missing-field-initializers)
-endif()
-
 # Disable Qt debug output in release builds
 if(CMAKE_BUILD_TYPE STREQUAL "Release")
     add_compile_definitions(QT_NO_DEBUG_OUTPUT)

--- a/nucleus/CMakeLists.txt
+++ b/nucleus/CMakeLists.txt
@@ -208,4 +208,6 @@ else()
     # imgui does not compile with -Werror. so we have to make it private for now.
     # better solutions welcome
     target_compile_options(nucleus PRIVATE -Wall -Wextra -pedantic -Werror)
+    # PUBLIC so every target linking nucleus inherits the suppression
+    target_compile_options(nucleus PUBLIC -Wno-missing-field-initializers)
 endif()


### PR DESCRIPTION
In C++, a designated initializer is still aggregate initialization, so any member you don't name is value-initialized to zero (nextInChain = nullptr, label = {}, etc.)  which is the intended default, rather than left uninitialized.